### PR TITLE
Feature/inline extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ a much more elegant fashion. The syntax of this tag works like this:
     {{ asset }}
 {% endwebpack %}
 ```
-Or if you want to have inline javascript code without including a file:
+Or if you want to have inline code without including a file:
 ```twig
-{% webpack <type: inline> %}
-    <javascript code>
+{% webpack <type: inline> [file-type] %}
+    <javascript, css, less, ... code>
 {% endwebpack %}
 ```
 
@@ -160,6 +160,37 @@ For more information about CSS file exportation, please refer to the [CSS loader
 > __Warning__: Due to the nature of split point detection, expressions are not parsed! Only strings types are accepted.
 > The reason behind this - as previously mentioned - performance. All twig templates are tokenized on request in debug-
 > mode. Just tokenizing them is a lot faster than actually parsing every single one of them.
+
+### More about the inline variant
+
+As mentioned in the example above, you may optionally specify a file type along with the `inline` type. This can be any
+type of file extension, just make sure you have the appropriate loaders enabled.
+
+For example, `js` will always work by default. However, `css` will only work if the `css-loader` is enabled. If you have
+the `less-loader` enabled, you can do something like this:
+
+```twig
+<section>
+    {% webpack inline less %}
+    <style>
+    @color: #f00;
+    @size: 42px;
+    
+    body {
+        color: @color;
+        section : {
+            size: @size;
+        }
+    }
+    </style>
+    {% endwebpack %}
+</section>
+```
+
+The compiler will automatically strip away the `<style>`- and/or `<script>`-tags and save the contents of the block to
+a file. This fill will then be used for inclusion in your template by utilizing either a `link`-tag or a `script` tag
+that refer to the compiled file.
+
 
 ## Configuration
 

--- a/src/Bundle/Twig/Token/WebpackTokenParser.php
+++ b/src/Bundle/Twig/Token/WebpackTokenParser.php
@@ -71,6 +71,7 @@ class WebpackTokenParser implements \Twig_TokenParserInterface
         if ($export_type === "inline") {
             return $this->parseInline($stream, $lineno);
         }
+
         return $this->parseType($stream, $lineno, $export_type);
     }
 
@@ -99,6 +100,10 @@ class WebpackTokenParser implements \Twig_TokenParserInterface
 
     private function parseInline(\Twig_TokenStream $stream, $lineno)
     {
+        if ($stream->test(\Twig_Token::NAME_TYPE)) {
+            $stream->next();
+        }
+
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
         $this->parser->subparse(function ($token) {
@@ -109,11 +114,11 @@ class WebpackTokenParser implements \Twig_TokenParserInterface
 
         $file = $this->parser->getEnvironment()->getLoader()->getCacheKey($stream->getFilename());
 
-        if (!isset($this->inline_blocks[$file])) {
+        if (! isset($this->inline_blocks[$file])) {
             $this->inline_blocks[$file] = 0;
         }
 
-        $file_name = md5($file . $this->inline_blocks[$file]). ".js";
+        $file_name = md5($file . $this->inline_blocks[$file]). '.' . 'js';
         $assets    = $this->extension->webpackAsset('cache.' . $file_name);
 
         $this->inline_blocks[$file]++;

--- a/src/Bundle/Twig/Token/WebpackTokenParser.php
+++ b/src/Bundle/Twig/Token/WebpackTokenParser.php
@@ -118,7 +118,7 @@ class WebpackTokenParser implements \Twig_TokenParserInterface
             $this->inline_blocks[$file] = 0;
         }
 
-        $file_name = md5($file . $this->inline_blocks[$file]). '.' . 'js';
+        $file_name = md5($file . $this->inline_blocks[$file]) . '.js';
         $assets    = $this->extension->webpackAsset('cache.' . $file_name);
 
         $this->inline_blocks[$file]++;

--- a/src/Bundle/Twig/TwigExtension.php
+++ b/src/Bundle/Twig/TwigExtension.php
@@ -62,12 +62,20 @@ class TwigExtension extends \Twig_Extension
      */
     public function webpackAsset($asset)
     {
-        $asset_id      = rtrim($this->public_path, '/') . '/' . Compiler::getAliasId($asset);
-        $document_root = isset($_SERVER['DOCUMENT_ROOT']) ? $_SERVER['DOCUMENT_ROOT'] : '';
+        // @FIXME: This method is used by the compiler which may or may not run from a CLI-environment. In this case the
+        //         variable DOCUMENT_ROOT isn't available and this method may produce unexpected behavior.
+
+        $asset_id        = rtrim($this->public_path, '/') . '/' . Compiler::getAliasId($asset);
+        $document_root   = isset($_SERVER['DOCUMENT_ROOT']) ? $_SERVER['DOCUMENT_ROOT'] : '';
+        $full_asset_path = $document_root . '/' . $asset_id;
 
         return [
-            'js'  => file_exists($document_root . '/' . $asset_id . '.js') ? $asset_id . '.js' : false,
-            'css' => file_exists($document_root . '/' . $asset_id . '.css') ? $asset_id . '.css' : false
+            'js'  => file_exists($full_asset_path . '.js')
+                ? $asset_id . '.js?' . filemtime($full_asset_path . '.js')
+                : false,
+            'css' => file_exists($full_asset_path . '.css')
+                ? $asset_id . '.css?' . filemtime($full_asset_path . '.css')
+                : false
         ];
     }
 

--- a/src/Component/Asset/Compiler.php
+++ b/src/Component/Asset/Compiler.php
@@ -103,8 +103,11 @@ class Compiler
 
         $output = $this->process->getOutput() . $this->process->getErrorOutput();
         $this->profiler->set('compiler.executed', true);
-        $this->profiler->set('compiler.successful', strpos($output, 'Error:') === false);
         $this->profiler->set('compiler.last_output', $output);
+        $this->profiler->set('compiler.successful',
+            strpos($output, 'Error:') === false &&
+            strpos($output, 'parse failed') === false
+        );
 
         if ($this->profiler->get('compiler.successful')) {
             $this->tracker->rebuild();

--- a/test/Component/Asset/TwigParserTest.php
+++ b/test/Component/Asset/TwigParserTest.php
@@ -46,19 +46,23 @@ class TwigParserTest extends \PHPUnit_Framework_TestCase
         //  5: {% webpack css %}
         //  6: {% webpack inline %}
         //  7: {% webpack inline %}
-        $this->tracker->expects($this->exactly(7))->method('resolveResourcePath')->willReturn('foobar');
+        //  8: {% webpack inline less %}
+        //  9: {% webpack inline css %}
+        $this->tracker->expects($this->exactly(9))->method('resolveResourcePath')->willReturn('foobar');
 
         $parser = new TwigParser($this->tracker, $this->twig, $this->cache_dir);
         $file   = $this->path . '/Resources/template.html.twig';
         $points = ($parser->findSplitPoints($file));
 
-        $this->assertCount(6, $points);
+        $this->assertCount(8, $points);
         $this->assertArrayHasKey('@BarBundle/app.js', $points);
         $this->assertArrayHasKey('@BarBundle/app2.js', $points);
         $this->assertArrayHasKey('@BarBundle/app3.js', $points);
         $this->assertArrayHasKey('@BarBundle/app4.js', $points);
         $this->assertArrayHasKey('cache/' . md5($file . 0) . '.js', $points);
         $this->assertArrayHasKey('cache/' . md5($file . 1) . '.js', $points);
+        $this->assertArrayHasKey('cache/' . md5($file . 2) . '.less', $points);
+        $this->assertArrayHasKey('cache/' . md5($file . 3) . '.css', $points);
 
         $this->assertContains('foobar', $points);
     }

--- a/test/Fixture/Resources/template.html.twig
+++ b/test/Fixture/Resources/template.html.twig
@@ -13,12 +13,27 @@
     <link rel="stylesheet" href="{{ asset }}">
 {% endwebpack %}
 
-{# and webpack inline #}
+{# and webpack inline with no extension given. It must fallback to "js" by default. #}
 {% webpack inline %}
     <script type="text/javascript">
         console.log("HENK");
     </script>
 {% endwebpack %}
-{% webpack inline %}
+
+{# Specified an extension. Webpack will also parse the contents by the given type. #}
+{% webpack inline js %}
     console.log("HENK");
+{% endwebpack %}
+
+{# Parse the contents as it were a LESS file. #}
+{% webpack inline less %}
+    @size: 42px;
+    * { font-size: @size; }
+{% endwebpack %}
+
+{# Parse the contents as it were a CSS file. Also, feel free to use style tags (for IDE syntax highlighting)... #}
+{% webpack inline css %}
+<style>
+    * { font-size: 42px; }
+</style>
 {% endwebpack %}


### PR DESCRIPTION
Allows for optionally specified languages in the `inline` variant of the `webpack` twig-block. See readme update for info & example.

There are no BC-breaks in this update.