### PR TITLE
Moved debug stuff to dev.yml, made fs use the service

### DIFF
--- a/src/Bundle/Command/CompileCommand.php
+++ b/src/Bundle/Command/CompileCommand.php
@@ -8,7 +8,6 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @TODO Add some decent logging interface to allow optional verbose output.
@@ -59,7 +58,7 @@ class CompileCommand extends Command
         $this->compiler->compile();
 
         $this->logger->info('[WEBPACK]: Dumping assets...');
-        $this->dumper->dump(new Filesystem());
+        $this->dumper->dump();
 
         $this->logger->debug($this->profiler->get('compiler.last_output'));
     }

--- a/src/Bundle/DependencyInjection/WebpackCompilerPass.php
+++ b/src/Bundle/DependencyInjection/WebpackCompilerPass.php
@@ -1,11 +1,8 @@
 <?php
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 
-use Hostnet\Bundle\WebpackBundle\EventListener\RequestListener;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Harold Iedema <hiedema@hostnet.nl>
@@ -55,18 +52,6 @@ class WebpackCompilerPass implements CompilerPassInterface
             ->getDefinition('hostnet_webpack.bridge.twig_extension')
             ->replaceArgument(0, $config['output']['public_path'])
             ->replaceArgument(1, $config['output']['dump_path']);
-
-        // Enable the request listener if we're running in debug mode.
-        if ($container->getParameter('kernel.debug') === true) {
-            $container->setDefinition(
-                'hostnet_webpack.bridge.request_listener',
-                (new Definition(RequestListener::class, [
-                    new Reference('hostnet_webpack.bridge.asset_tracker'),
-                    new Reference('hostnet_webpack.bridge.asset_compiler'),
-                    new Reference('hostnet_webpack.bridge.asset_dumper')
-                ]))->addTag('kernel.event_listener', ['event' => 'kernel.request', 'method' => 'onRequest'])
-            );
-        }
 
         // Ensure webpack is installed in the given (or detected) node_modules directory.
         if (false === ($webpack = realpath($config['node']['node_modules_path'] . '/webpack/bin/webpack.js'))) {

--- a/src/Bundle/DependencyInjection/WebpackExtension.php
+++ b/src/Bundle/DependencyInjection/WebpackExtension.php
@@ -20,7 +20,13 @@ class WebpackExtension extends Extension
     public function load(array $config, ContainerBuilder $container)
     {
         // Load configuration
-        (new YamlFileLoader($container, (new FileLocator(__DIR__ . '/../Resources/config'))))->load('webpack.yml');
+        $loader = new YamlFileLoader($container, (new FileLocator(__DIR__ . '/../Resources/config')));
+        $loader->load('webpack.yml');
+
+        // Enable the request listener if we're running in dev.
+        if ($container->getParameter('kernel.environment') === 'dev') {
+            $loader->load('dev.yml');
+        }
 
         // Retrieve all configuration entities
         $builder_definition   = $container->getDefinition('hostnet_webpack.bridge.config_generator');
@@ -92,8 +98,7 @@ class WebpackExtension extends Extension
 
         $configuration = new Configuration(array_keys($bundles), $config_class_names);
 
-        $r = new \ReflectionClass(get_class($configuration));
-        $container->addResource(new FileResource($r->getFileName()));
+        $container->addResource(new FileResource((new \ReflectionClass(get_class($configuration)))->getFileName()));
 
         return $configuration;
     }

--- a/src/Bundle/EventListener/RequestListener.php
+++ b/src/Bundle/EventListener/RequestListener.php
@@ -4,8 +4,6 @@ namespace Hostnet\Bundle\WebpackBundle\EventListener;
 use Hostnet\Component\Webpack\Asset\Compiler;
 use Hostnet\Component\Webpack\Asset\Dumper;
 use Hostnet\Component\Webpack\Asset\Tracker;
-use Hostnet\Component\Webpack\Profiler\Profiler;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 /**
@@ -53,6 +51,6 @@ class RequestListener
             $this->compiler->compile();
         }
 
-        $this->dumper->dump(new Filesystem());
+        $this->dumper->dump();
     }
 }

--- a/src/Bundle/Resources/config/dev.yml
+++ b/src/Bundle/Resources/config/dev.yml
@@ -1,0 +1,15 @@
+services:
+
+    hostnet_webpack.bridge.request_listener:
+        class: Hostnet\Bundle\WebpackBundle\EventListener\RequestListener
+        arguments:
+            - '@hostnet_webpack.bridge.asset_tracker'
+            - '@hostnet_webpack.bridge.asset_compiler'
+            - '@hostnet_webpack.bridge.asset_dumper'
+        tags:
+            - { name: kernel.event_listener, event: kernel.request, method: onRequest}
+
+    hostnet_webpack.bridge.profiler:
+        class: Hostnet\Component\Webpack\Profiler\Profiler
+        tags:
+            - { name: data_collector, template: WebpackBundle::profiler.html.twig, id: webpack }

--- a/src/Bundle/Resources/config/webpack.yml
+++ b/src/Bundle/Resources/config/webpack.yml
@@ -32,6 +32,7 @@ services:
     hostnet_webpack.bridge.asset_dumper:
         class: Hostnet\Component\Webpack\Asset\Dumper
         arguments:
+            - '@filesystem'
             - '@logger'
             - [] # bundles
             - '' # 'public' dir
@@ -70,7 +71,3 @@ services:
         tags:
             - { name: twig.extension }
 
-    hostnet_webpack.bridge.profiler:
-        class: Hostnet\Component\Webpack\Profiler\Profiler
-        tags:
-            - { name: data_collector, template: "WebpackBundle::profiler.html.twig", id: "webpack" }

--- a/test/Bundle/DependencyInjection/WebpackCompilerPassTest.php
+++ b/test/Bundle/DependencyInjection/WebpackCompilerPassTest.php
@@ -7,6 +7,7 @@ use Hostnet\Fixture\WebpackBundle\Bundle\FooBundle\FooBundle;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplateFinderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @covers \Hostnet\Bundle\WebpackBundle\DependencyInjection\WebpackCompilerPass
@@ -22,9 +23,10 @@ class WebpackCompilerPassTest extends \PHPUnit_Framework_TestCase
         $fixture_dir = realpath(__DIR__ . '/../../Fixture');
 
         $container->setParameter('kernel.bundles', ['FooBundle' => FooBundle::class, 'BarBundle' => BarBundle::class]);
-        $container->setParameter('kernel.debug', true);
+        $container->setParameter('kernel.environment', 'dev');
         $container->setParameter('kernel.root_dir', $fixture_dir);
         $container->setParameter('kernel.cache_dir', realpath($fixture_dir . '/cache'));
+        $container->set('filesystem', new Filesystem());
         $container->set('templating.finder', $this->getMock(TemplateFinderInterface::class));
         $container->set('twig', $this->getMock(\Twig_Environment::class));
         $container->set('logger', $this->getMock(LoggerInterface::class));
@@ -59,9 +61,10 @@ class WebpackCompilerPassTest extends \PHPUnit_Framework_TestCase
         $fixture_dir = realpath(__DIR__ . '/../../Fixture');
 
         $container->setParameter('kernel.bundles', ['FooBundle' => FooBundle::class, 'BarBundle' => BarBundle::class]);
-        $container->setParameter('kernel.debug', true);
+        $container->setParameter('kernel.environment', 'dev');
         $container->setParameter('kernel.root_dir', $fixture_dir);
         $container->setParameter('kernel.cache_dir', realpath($fixture_dir . '/cache'));
+        $container->set('filesystem', new Filesystem());
         $container->set('templating.finder', $this->getMock(TemplateFinderInterface::class));
         $container->set('twig', $this->getMock(\Twig_Environment::class));
         $container->set('logger', $this->getMock(LoggerInterface::class));

--- a/test/Bundle/DependencyInjection/WebpackExtensionTest.php
+++ b/test/Bundle/DependencyInjection/WebpackExtensionTest.php
@@ -20,7 +20,7 @@ class WebpackExtensionTest extends \PHPUnit_Framework_TestCase
         $extension = new WebpackExtension();
 
         $container->setParameter('kernel.bundles', []);
-        $container->setParameter('kernel.debug', true);
+        $container->setParameter('kernel.environment', 'dev');
 
         // This should not fail.
         $extension->load([], $container);

--- a/test/Component/Asset/CompilerTest.php
+++ b/test/Component/Asset/CompilerTest.php
@@ -18,7 +18,7 @@ class CompilerTest extends \PHPUnit_Framework_TestCase
     private $process;
     private $cache_path;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->profiler    = $this->getMockBuilder(Profiler::class)->disableOriginalConstructor()->getMock();
         $this->tracker     = $this->getMockBuilder(Tracker::class)->disableOriginalConstructor()->getMock();

--- a/test/Component/Asset/DumperTest.php
+++ b/test/Component/Asset/DumperTest.php
@@ -20,11 +20,11 @@ class DumperTest extends \PHPUnit_Framework_TestCase
      */
     private $fixture_path;
 
-    /** {@inheritdoc} */
-    public function setUp()
+    protected function setUp()
     {
         $this->fixture_path = realpath(__DIR__ . '/../../Fixture');
         $this->dumper       = new Dumper(
+            $this->getMock(Filesystem::class),
             $this->getMock(LoggerInterface::class),
             [
                 'FooBundle' => $this->fixture_path . '/Bundle/FooBundle',
@@ -42,6 +42,6 @@ class DumperTest extends \PHPUnit_Framework_TestCase
 
     public function testDumpDefaults()
     {
-        $this->dumper->dump($this->getMock(Filesystem::class));
+        $this->dumper->dump();
     }
 }


### PR DESCRIPTION
The profiler is only load in dev, not when debugging. Therefore it makes more sense to load it based on the environment rather than the debug flag. I've also moved the `RequestListener` to this configuration file for consistency. `dev.yml` is only loaded when `kernel.environment === dev` .