### PR TITLE
Removed all references to DOCUMENT_ROOT for CLI compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ locations. The reasoning behind this decision is because webpack assets are comp
 accessible from the browser.
 
  - `Resources/assets` contains files that are compiled by webpack.
- - `Resources/public` contains assets that are either symlinked or copied to `/web/bundles/<lowercased_bundle_name>/`
+ - `Resources/public` contains assets that are either symlinked or copied to `/<dump_path>/<lowercased_bundle_name>/`
 
 Both of these directories are being watched when running in _debug mode_. When an asset has been added, modified or
 deleted, compiled sources are updated directly.
@@ -50,6 +50,9 @@ Install using [composer](https://getcomposer.org/).
 }
 ```
 Once installed, enable the bundle `Hostnet\Bundle\WebpackBundle\WebpackBundle` in the `AppKernel` class.
+
+> ___Warning___: In order to have the webpack twig tag detect the compiled files, webpack has to be compiled already. Therefore
+>  it's mandatory to run the compile command `webpack:compile` __before__ the cache warmpup.
 
 ## Quick how-to
 
@@ -99,7 +102,7 @@ and AMD-style loading of files. As you might have noticed, the example above ref
 referencing dependencies throughout the entire application.
 
 The `logo.png` file, located in the `Resources/public` directory will be symlinked or copied to
-`/web/bundles/<lowercased_bundle_name>` automatically. You should place any file that does not need processing in the
+`/<dump_path>/<lowercased_bundle_name>` automatically. You should place any file that does not need processing in the
 public directory to avoid unnecessary load times in debug mode (app_dev).
 
 Here is a simple image module that returns an image HTML-tag as string.
@@ -280,12 +283,12 @@ webpack:
 webpack:
     output:
         path: '%kernel.root_dir%/../web'
-        dump_path: '%kernel.root_dir%/../web/bundles'
+        dump_path: '/bundles'            # public assets will be copied to '%kernel.root_dir%/../web/bundles'
         public_path: '/'
 ```
 
-The `public_path` value represents the asset paths from a client-side perspective. Therefore, it must specify a path
-that exists inside the DOCUMENT_ROOT directory.
+The `public_path` value represents the asset paths from a client-side perspective. Therefore, it must specify the path
+of your app(_dev).php as exposed from the web e.g. somedomain.com/my-web/app.php would make it `%kernel.root_dir%/../web/my-app`
 
 For example, if the `output.path` value is `%kernel.root_dir/../web/packed`, the value of `output.public_path` must be
 set to `/packed`.
@@ -313,7 +316,7 @@ webpack:
         node_modules_path: '%kernel.root_dir%/../node_modules'
     output:
         path: '%kernel.root_dir%/../web/compiled'
-        dump_path: '%kernel.root_dir%/../web/bundles'
+        dump_path: '/bundles'
         public_path: '/compiled'
         common_id: 'shared'
     loaders:

--- a/src/Bundle/DependencyInjection/WebpackCompilerPass.php
+++ b/src/Bundle/DependencyInjection/WebpackCompilerPass.php
@@ -19,9 +19,11 @@ class WebpackCompilerPass implements CompilerPassInterface
         $bundles         = $container->getParameter('kernel.bundles');
         $config          = $container->getParameter('hostnet_webpack_config');
         $tracked_bundles = $config['bundles'];
-        $asset_path      = 'Resources' . DIRECTORY_SEPARATOR . 'assets';
-        $public_path     = 'Resources' . DIRECTORY_SEPARATOR . 'public';
+        $asset_res_path  = 'Resources' . DIRECTORY_SEPARATOR . 'assets';
+        $public_res_path = 'Resources' . DIRECTORY_SEPARATOR . 'public';
+        $public_path     = $config['output']['public_path'];
         $dump_path       = $config['output']['dump_path'];
+        $web_dir         = $config['output']['path'];
         $bundle_paths    = [];
 
         foreach ($bundles as $name => $class) {
@@ -32,7 +34,7 @@ class WebpackCompilerPass implements CompilerPassInterface
             $bundle_paths[$name] = realpath(dirname((new \ReflectionClass($class))->getFileName()));
         }
 
-        $asset_tracker->replaceArgument(4, $asset_path);
+        $asset_tracker->replaceArgument(4, $asset_res_path);
         $asset_tracker->replaceArgument(5, $bundle_paths);
 
         // Configure the compiler process.
@@ -44,8 +46,8 @@ class WebpackCompilerPass implements CompilerPassInterface
         $container
             ->getDefinition('hostnet_webpack.bridge.asset_dumper')
             ->replaceArgument(1, $bundle_paths)
-            ->replaceArgument(2, $public_path)
-            ->replaceArgument(3, $dump_path);
+            ->replaceArgument(2, $public_res_path)
+            ->replaceArgument(3, rtrim($web_dir, '\\/') . DIRECTORY_SEPARATOR . $dump_path);
 
         $container
             ->getDefinition('hostnet_webpack.bridge.asset_compiler')
@@ -53,8 +55,9 @@ class WebpackCompilerPass implements CompilerPassInterface
 
         $container
             ->getDefinition('hostnet_webpack.bridge.twig_extension')
-            ->replaceArgument(0, $config['output']['public_path'])
-            ->replaceArgument(1, $config['output']['dump_path']);
+            ->replaceArgument(0, $web_dir)
+            ->replaceArgument(1, $public_path)
+            ->replaceArgument(2, $dump_path);
 
         // Enable the request listener if we're running in debug mode.
         if ($container->getParameter('kernel.debug') === true) {

--- a/src/Bundle/Resources/config/webpack.yml
+++ b/src/Bundle/Resources/config/webpack.yml
@@ -65,6 +65,7 @@ services:
     hostnet_webpack.bridge.twig_extension:
         class: Hostnet\Bundle\WebpackBundle\Twig\TwigExtension
         arguments:
+            - '' # web_path
             - '' # public_path
             - '' # dump_path
         tags:

--- a/src/Bundle/Twig/Token/WebpackTokenParser.php
+++ b/src/Bundle/Twig/Token/WebpackTokenParser.php
@@ -26,13 +26,12 @@ class WebpackTokenParser implements \Twig_TokenParserInterface
     private $extension;
 
     /**
-     * @var int
+     * @var int[]
      */
     private $inline_blocks = [];
 
     /**
      * @param TwigExtension $extension
-     * @param string        $cache_dird
      */
     public function __construct(TwigExtension $extension)
     {
@@ -75,6 +74,13 @@ class WebpackTokenParser implements \Twig_TokenParserInterface
         return $this->parseType($stream, $lineno, $export_type);
     }
 
+    /**
+     * @param \Twig_TokenStream $stream
+     * @param int               $lineno
+     * @param string            $export_type
+     * @return WebpackNode
+     * @throws \Twig_Error_Syntax
+     */
     private function parseType(\Twig_TokenStream $stream, $lineno, $export_type)
     {
         $files = [];
@@ -98,6 +104,12 @@ class WebpackTokenParser implements \Twig_TokenParserInterface
         return new WebpackNode([$body], ['files' => $files], $lineno, $this->getTag());
     }
 
+    /**
+     * @param \Twig_TokenStream $stream
+     * @param int               $lineno
+     * @return WebpackInlineNode
+     * @throws \Twig_Error_Syntax
+     */
     private function parseInline(\Twig_TokenStream $stream, $lineno)
     {
         if ($stream->test(\Twig_Token::NAME_TYPE)) {

--- a/src/Bundle/Twig/TwigExtension.php
+++ b/src/Bundle/Twig/TwigExtension.php
@@ -10,7 +10,10 @@ use Hostnet\Component\Webpack\Asset\Compiler;
  */
 class TwigExtension extends \Twig_Extension
 {
-    const FUNCTION_NAME = 'webpack_asset';
+    /**
+     * @var string
+     */
+    private $web_dir;
 
     /**
      * @var string
@@ -23,11 +26,13 @@ class TwigExtension extends \Twig_Extension
     private $dump_path;
 
     /**
-     * @param string $public_path : webpack.output.public_path
-     * @param string $bundle_path : webpack.output.dump_path
+     * @param string $web_dir     webpack.output.path
+     * @param string $public_path webpack.output.public_path
+     * @param string $dump_path   webpack.output.dump_path
      */
-    public function __construct($public_path = '', $dump_path = '')
+    public function __construct($web_dir, $public_path, $dump_path)
     {
+        $this->web_dir     = $web_dir;
         $this->public_path = $public_path;
         $this->dump_path   = $dump_path;
     }
@@ -48,7 +53,7 @@ class TwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction(self::FUNCTION_NAME, [$this, 'webpackAsset']),
+            new \Twig_SimpleFunction('webpack_asset', [$this, 'webpackAsset']),
             new \Twig_SimpleFunction('webpack_public', [$this, 'webpackPublic']),
         ];
     }
@@ -62,12 +67,8 @@ class TwigExtension extends \Twig_Extension
      */
     public function webpackAsset($asset)
     {
-        // @FIXME: This method is used by the compiler which may or may not run from a CLI-environment. In this case the
-        //         variable DOCUMENT_ROOT isn't available and this method may produce unexpected behavior.
-
-        $asset_id        = rtrim($this->public_path, '/') . '/' . Compiler::getAliasId($asset);
-        $document_root   = isset($_SERVER['DOCUMENT_ROOT']) ? $_SERVER['DOCUMENT_ROOT'] : '';
-        $full_asset_path = $document_root . '/' . $asset_id;
+        $asset_id        = rtrim($this->public_path, '/\\') . '/' . Compiler::getAliasId($asset);
+        $full_asset_path = rtrim($this->web_dir, '/\\') . '/' . ltrim($asset_id, '/\\');
 
         return [
             'js'  => file_exists($full_asset_path . '.js')
@@ -85,26 +86,25 @@ class TwigExtension extends \Twig_Extension
      * For example:
      *      given url: "@AppBundle/images/foo.png"
      *      real path: "AppBundle/Resources/public/images/foo.png"
-     *      mapped to: "/bundles/app/images/foo.png"
+     *      mapped to: "/<dump_path>/app/images/foo.png"
      *
-     * The mapped url is either a symlink or copied asset that resides in the web/bundles directory.
+     * The mapped url is either a symlink or copied asset that resides in the <dump_path> directory.
      *
      * @param  string $url
      * @return string
      */
     public function webpackPublic($url)
     {
-        $document_root = realpath(isset($_SERVER['DOCUMENT_ROOT']) ? $_SERVER['DOCUMENT_ROOT'] : '');
-        $public_dir    = substr(realpath($this->dump_path), strlen($document_root));
+        $public_dir = rtrim($this->public_path, '/\\') . '/' . ltrim($this->dump_path, '/\\');
 
-        $url = preg_replace_callback('/^@(\w+)/', function ($match) {
-            $str = $match[1];
+        $url = preg_replace_callback('/^@(?<bundle>\w+)/', function ($match) {
+            $str = $match['bundle'];
             if (substr($str, strlen($str) - 6) === 'Bundle') {
                 $str = substr($str, 0, strlen($str) - 6);
             }
             return strtolower($str);
         }, $url);
 
-        return str_replace('\\', '/', $public_dir) . '/' . $url;
+        return rtrim(str_replace('\\', '/', $public_dir), '/') . '/' . $url;
     }
 }

--- a/src/Bundle/WebpackBundle.php
+++ b/src/Bundle/WebpackBundle.php
@@ -1,6 +1,8 @@
 <?php
 namespace Hostnet\Bundle\WebpackBundle;
 
+use Hostnet\Bundle\WebpackBundle\DependencyInjection\WebpackCompilerPass;
+use Hostnet\Bundle\WebpackBundle\DependencyInjection\WebpackExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -16,12 +18,12 @@ class WebpackBundle extends Bundle
     {
         parent::build($container);
 
-        $container->addCompilerPass(new DependencyInjection\WebpackCompilerPass());
+        $container->addCompilerPass(new WebpackCompilerPass());
     }
 
     /** {@inheritdoc} */
     public function getContainerExtension()
     {
-        return new DependencyInjection\WebpackExtension();
+        return new WebpackExtension();
     }
 }

--- a/src/Component/Asset/Dumper.php
+++ b/src/Component/Asset/Dumper.php
@@ -6,7 +6,7 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * Exports resources from the 'public' directory to web/bundles/<bundle_name> whenever a resource has been changed.
+ * Exports resources from the 'public' directory to <dump_path>/<bundle_name> whenever a resource has been changed.
  *
  * @author Harold Iedema <hiedema@hostnet.nl>
  */

--- a/src/Component/Asset/Tracker.php
+++ b/src/Component/Asset/Tracker.php
@@ -274,7 +274,7 @@ class Tracker
         // Find and replace the @BundleName with the absolute path to the bundle.
         $matches = [];
         preg_match('/@(\w+)/', $path, $matches);
-        if (isset($matches[0]) && isset($matches[1]) && isset($this->bundle_paths[$matches[1]])) {
+        if (isset($matches[0], $matches[1], $this->bundle_paths[$matches[1]])) {
             $resolved_path = realpath(str_replace($matches[0], $this->bundle_paths[$matches[1]], $path));
             return $resolved_path;
         }
@@ -292,7 +292,7 @@ class Tracker
     {
         $matches = [];
         preg_match('/@(\w+)/', $path, $matches);
-        if (isset($matches[0]) && isset($matches[1])) {
+        if (isset($matches[0], $matches[1])) {
             $template = realpath(str_replace(
                 $matches[0],
                 $this->bundle_paths[$matches[1]] . DIRECTORY_SEPARATOR . trim($this->asset_dir, "\\/"),

--- a/src/Component/Asset/TwigParser.php
+++ b/src/Component/Asset/TwigParser.php
@@ -39,7 +39,7 @@ class TwigParser
 
         while (! $stream->isEOF() && $token = $stream->next()) {
             // {{ webpack_asset(...) }}
-            if ($token->test(\Twig_Token::NAME_TYPE, TwigExtension::FUNCTION_NAME)) {
+            if ($token->test(\Twig_Token::NAME_TYPE, 'webpack_asset')) {
                 // We found the webpack function!
                 $asset          = $this->getAssetFromStream($template_file, $stream);
                 $points[$asset] = $this->resolveAssetPath($asset, $template_file, $token);

--- a/src/Component/Configuration/Config/OutputConfig.php
+++ b/src/Component/Configuration/Config/OutputConfig.php
@@ -29,7 +29,7 @@ final class OutputConfig implements ConfigInterface, ConfigExtensionInterface
                 ->addDefaultsIfNotSet()
                 ->children()
                     ->scalarNode('path')->defaultValue('%kernel.root_dir%/../web')->end()
-                    ->scalarNode('dump_path')->defaultValue('%kernel.root_dir%/../web/bundles')->end()
+                    ->scalarNode('dump_path')->defaultValue('/bundles')->end()
                     ->scalarNode('filename')->defaultValue('[name].js')->end()
                     ->scalarNode('common_id')->defaultValue('common')->end()
                     ->scalarNode('chunk_filename')->defaultValue('[name].[hash].chunk.js')->end()

--- a/src/Component/Configuration/ConfigExtensionInterface.php
+++ b/src/Component/Configuration/ConfigExtensionInterface.php
@@ -1,7 +1,6 @@
 <?php
 namespace Hostnet\Component\Webpack\Configuration;
 
-use Hostnet\Component\Webpack\Configuration\CodeBlock;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 /**

--- a/test/Bundle/Twig/Token/WebpackTokenParserTest.php
+++ b/test/Bundle/Twig/Token/WebpackTokenParserTest.php
@@ -11,7 +11,7 @@ class WebpackTokenParserTest extends \PHPUnit_Framework_TestCase
 {
     public function testParser()
     {
-        $extension = $this->getMock(TwigExtension::class);
+        $extension = new TwigExtension(__DIR__, '/', '/bundles');
         $parser    = new WebpackTokenParser($extension);
 
         $this->assertEquals(WebpackTokenParser::TAG_NAME, $parser->getTag());

--- a/test/Bundle/Twig/TwigExtensionTest.php
+++ b/test/Bundle/Twig/TwigExtensionTest.php
@@ -9,11 +9,33 @@ class TwigExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function testExtension()
     {
-        $extension = new TwigExtension('foobar');
+        $extension = new TwigExtension(__DIR__, '/', '/bundles');
 
         $this->assertEquals('webpack', $extension->getName());
         $this->assertCount(2, $extension->getFunctions());
         $this->assertCount(1, $extension->getTokenParsers());
         $this->assertEquals(['js'  => false, 'css' => false], $extension->webpackAsset('@AppBundle/app.js'));
+    }
+
+    /**
+     * @dataProvider assetProvider
+     */
+    public function testAssets($expected, $asset, $web_dir, $dump_path, $public_path)
+    {
+        $extension = new TwigExtension($web_dir, $public_path, $dump_path);
+        $this->assertEquals($expected, $extension->webpackPublic($asset));
+    }
+
+    public function assetProvider()
+    {
+        return [
+            ['/bundles/img.png', 'img.png', __DIR__ . '/web/', '/bundles/', '/'],
+            ['/img.png', 'img.png', __DIR__ . 'web/', '/', '/'],
+            ['/bundles/app/img.png', '@App/img.png', __DIR__ . '/../web/', '/bundles/', '/'],
+            ['/some/dir/app/img.png', '@App/img.png', __DIR__ . './web/', '/some/dir/', '/'],
+            ['/bundles/some/img.png', '@SomeBundle/img.png', __DIR__ . '/../web/', '/bundles/', '/'],
+            ['/bundles/some/test/img.png', '@SomeBundle/test/img.png', './web/', '/bundles/', '/'],
+            ['/something/else/some/test/img.png', '@SomeBundle/test/img.png', '/web/', '/something/else/', '/'],
+        ];
     }
 }


### PR DESCRIPTION
As of symfony 2.7.6, a bug has been fixed which prevent from twig templates being processed and cached during deployment. This was always done on the first request in 2.7.5 and before. This resulted in `webpack:compile` being ran too late in the process. Previously (because of DOCUMENT_ROOT) it was impossible to generate the twig cache on the command line with `cache:warmup --env=prod` and because of this bug, we never noticed this issue in `webpack:compile`.

This PR aims to fix this issue by making it possible to correctly process the `{% webpack js/css %}` parsing. The path in which everything is supposed to be dumped is already available so it's simply added.

Previously the dump path had to be given absolutely, this is now calculated when the container compiles.

___Old config___
```yml
webpack:
    output:
        path: '%kernel.root_dir%/../web'
        dump_path: '%kernel.root_dir%/../web/bundles'  
```

___New Config___
```yml
webpack:
    output:
        path: '%kernel.root_dir%/../web'
        dump_path: '/bundles'  
```