### PR TITLE
Reverted config change to be BC

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,23 +275,24 @@ webpack:
 
 ### Asset output directories
 
-- Dumped assets from the "public" directory are symlinked or copied to the `<output.path>/<output.dump_dir>` directory.
+- Dumped assets from the "public" directory are symlinked or copied to the `<output.dump_dir>` directory.
 - Compiled assets from the "assets" directory are written to the `<output.path>` directory.
 - The twig function `webpack_asset` returns compiled file names prefixed with the `<output.public_path>` directory.
 
 ```yaml
 webpack:
     output:
-        path: '%kernel.root_dir%/../web'
-        dump_path: '/bundles'            # public assets will be copied to '%kernel.root_dir%/../web/bundles'
-        public_path: '/'
+        path: '%kernel.root_dir%/../web/compiled/'
+        dump_path: '%kernel.root_dir%/../web/bundles/'
+        public_path: '/compiled/'
 ```
 
-The `public_path` value represents the asset paths from a client-side perspective. Therefore, it must specify the path
-of your app(_dev).php as exposed from the web e.g. somedomain.com/my-web/app.php would make it `%kernel.root_dir%/../web/my-app`
+The `path` value represents the asset paths from a client-side perspective. Therefore, it must specify the path
+of your app(_dev).php as exposed from the web e.g. somedomain.com/my-web/app.php would make it
+`%kernel.root_dir%/../web/my-app/compiled/` with the above example.
 
-For example, if the `output.path` value is `%kernel.root_dir/../web/packed`, the value of `output.public_path` must be
-set to `/packed`.
+If the `output.path` value is `%kernel.root_dir/../web/packed/`, the value of `output.public_path` must be
+set to `/packed/`.
 
 ### Ideal configuration
 
@@ -315,9 +316,9 @@ webpack:
         binary: '/path/to/node'
         node_modules_path: '%kernel.root_dir%/../node_modules'
     output:
-        path: '%kernel.root_dir%/../web/compiled'
-        dump_path: '/bundles'
-        public_path: '/compiled'
+        path: '%kernel.root_dir%/../web/compiled/'
+        dump_path: '%kernel.root_dir%/../web/bundles/'
+        public_path: '/compiled/'
         common_id: 'shared'
     loaders:
         css:

--- a/src/Bundle/Twig/TwigExtension.php
+++ b/src/Bundle/Twig/TwigExtension.php
@@ -26,9 +26,9 @@ class TwigExtension extends \Twig_Extension
     private $dump_path;
 
     /**
-     * @param string $web_dir     webpack.output.path
-     * @param string $public_path webpack.output.public_path
-     * @param string $dump_path   webpack.output.dump_path
+     * @param string $web_dir
+     * @param string $public_path
+     * @param string $dump_path
      */
     public function __construct($web_dir, $public_path, $dump_path)
     {
@@ -67,8 +67,8 @@ class TwigExtension extends \Twig_Extension
      */
     public function webpackAsset($asset)
     {
-        $asset_id        = rtrim($this->public_path, '/\\') . '/' . Compiler::getAliasId($asset);
-        $full_asset_path = rtrim($this->web_dir, '/\\') . '/' . ltrim($asset_id, '/\\');
+        $asset_id        = $this->public_path . '/' . Compiler::getAliasId($asset);
+        $full_asset_path = $this->web_dir . '/' . $asset_id;
 
         return [
             'js'  => file_exists($full_asset_path . '.js')
@@ -95,7 +95,7 @@ class TwigExtension extends \Twig_Extension
      */
     public function webpackPublic($url)
     {
-        $public_dir = rtrim($this->public_path, '/\\') . '/' . ltrim($this->dump_path, '/\\');
+        $public_dir = '/' . ltrim($this->dump_path, '/');
 
         $url = preg_replace_callback('/^@(?<bundle>\w+)/', function ($match) {
             $str = $match['bundle'];
@@ -105,6 +105,6 @@ class TwigExtension extends \Twig_Extension
             return strtolower($str);
         }, $url);
 
-        return rtrim(str_replace('\\', '/', $public_dir), '/') . '/' . $url;
+        return rtrim($public_dir, '/') . '/' . ltrim($url, '/');
     }
 }

--- a/src/Component/Asset/Dumper.php
+++ b/src/Component/Asset/Dumper.php
@@ -15,23 +15,23 @@ class Dumper
     private $fs;
     private $logger;
     private $bundle_paths;
-    private $public_dir;
+    private $public_res_path;
     private $output_dir;
 
     /**
      * @param Filesystem      $fs
      * @param LoggerInterface $logger
      * @param array           $bundle_paths
-     * @param string          $public_dir
+     * @param string          $public_res_path
      * @param string          $output_dir
      */
-    public function __construct(Filesystem $fs, LoggerInterface $logger, array $bundle_paths, $public_dir, $output_dir)
+    public function __construct(Filesystem $fs, LoggerInterface $logger, array $bundle_paths, $public_res_path, $output_dir)
     {
-        $this->fs           = $fs;
-        $this->logger       = $logger;
-        $this->bundle_paths = $bundle_paths;
-        $this->public_dir   = $public_dir;
-        $this->output_dir   = $output_dir;
+        $this->fs              = $fs;
+        $this->logger          = $logger;
+        $this->bundle_paths    = $bundle_paths;
+        $this->public_res_path = $public_res_path;
+        $this->output_dir      = $output_dir;
     }
 
     /**
@@ -40,8 +40,8 @@ class Dumper
     public function dump()
     {
         foreach ($this->bundle_paths as $name => $path) {
-            if (file_exists($path . DIRECTORY_SEPARATOR . $this->public_dir)) {
-                $this->dumpBundle($name, $path . DIRECTORY_SEPARATOR . $this->public_dir);
+            if (file_exists($path . DIRECTORY_SEPARATOR . $this->public_res_path)) {
+                $this->dumpBundle($name, $path . DIRECTORY_SEPARATOR . $this->public_res_path);
             }
         }
     }

--- a/src/Component/Configuration/Config/OutputConfig.php
+++ b/src/Component/Configuration/Config/OutputConfig.php
@@ -26,10 +26,17 @@ final class OutputConfig implements ConfigInterface, ConfigExtensionInterface
     {
         $node_builder
             ->arrayNode('output')
+                ->validate()
+                    ->ifTrue(function ($c) {
+                        return !preg_match(sprintf('~(?<web_dir>.*)%s$~', rtrim($c['public_path'], '\\/')), rtrim($c['path'], '\\/'));
+                    })
+                    ->thenInvalid('webpack.output.public_path must be equal to the end of the webpack.output.path.')
+                ->end()
                 ->addDefaultsIfNotSet()
                 ->children()
-                    ->scalarNode('path')->defaultValue('%kernel.root_dir%/../web')->end()
-                    ->scalarNode('dump_path')->defaultValue('/bundles')->end()
+                    ->scalarNode('path')->defaultValue('%kernel.root_dir%/../web/compiled/')->end()
+                    ->scalarNode('dump_path')->defaultValue('%kernel.root_dir%/../web/bundles/')->end()
+                    ->scalarNode('public_path')->defaultValue('/compiled/')->end()
                     ->scalarNode('filename')->defaultValue('[name].js')->end()
                     ->scalarNode('common_id')->defaultValue('common')->end()
                     ->scalarNode('chunk_filename')->defaultValue('[name].[hash].chunk.js')->end()
@@ -39,7 +46,6 @@ final class OutputConfig implements ConfigInterface, ConfigExtensionInterface
                     ->booleanNode('devtool_line_to_line')->defaultFalse()->end()
                     ->scalarNode('hot_update_chunk_filename')->defaultValue('[id].[hash].hot-update.js')->end()
                     ->scalarNode('hot_update_main_filename')->defaultValue('[hash].hot-update.json')->end()
-                    ->scalarNode('public_path')->defaultValue('/')->end()
                     ->scalarNode('jsonp_function')->defaultValue('webpackJsonp')->end()
                     ->scalarNode('hot_update_function')->defaultValue('webpackHotUpdate')->end()
                     ->booleanNode('path_info')->defaultFalse()->end()

--- a/test/Fixture/config/config.yml
+++ b/test/Fixture/config/config.yml
@@ -9,6 +9,6 @@ webpack:
     node:
         node_modules_path: %kernel.root_dir%/node_modules
     output:
-        path: %kernel.root_dir%
-        dump_path: /bundles
-        public_path: /
+        path: %kernel.root_dir%/cache/compiled/
+        dump_path: %kernel.root_dir%/cache/bundles/
+        public_path: /compiled/

--- a/test/Functional/AssetTest.php
+++ b/test/Functional/AssetTest.php
@@ -1,0 +1,54 @@
+<?php
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @author Iltar van der Berg <ivanderberg@hostnet.nl>
+ */
+class AssetTest extends KernelTestCase
+{
+    private $compiled;
+
+    protected function setUp()
+    {
+        static::bootKernel();
+        $this->compiled = static::$kernel->getContainer()->getParameter('kernel.root_dir') . '/cache/compiled/';
+
+        if (!file_exists($this->compiled)) {
+            mkdir($this->compiled);
+        }
+    }
+
+    public function testPublicAsset()
+    {
+        static::bootKernel();
+
+        $twig_ext = static::$kernel->getContainer()->get('hostnet_webpack.bridge.twig_extension');
+
+        $this->assertEquals('/bundles/henk.png', $twig_ext->webpackPublic('henk.png'));
+    }
+
+    public function testCompiledAsset()
+    {
+        $container = static::$kernel->getContainer();
+        $twig_ext  = $container->get('hostnet_webpack.bridge.twig_extension');
+
+//        $this->assertEquals([
+//            'js'  => false,
+//            'css' => false,
+//        ], $twig_ext->webpackAsset('henk'));
+
+        touch($this->compiled . 'app.henk.js');
+        touch($this->compiled . 'app.henk.css');
+
+        $resources = $twig_ext->webpackAsset('@App/henk.js');
+        $this->assertContains('app.henk.js?', (string) $resources['js']);
+        $this->assertContains('app.henk.css?', (string) $resources['css']);
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        `rm -rf {$this->compiled}`;
+    }
+}

--- a/test/Functional/CompileTest.php
+++ b/test/Functional/CompileTest.php
@@ -7,20 +7,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  */
 class CompileTest extends KernelTestCase
 {
-    /** @dataProvider envProvider */
-    public function testContainer($env)
-    {
-        static::bootKernel(['environment' => $env, 'debug' => false]);
 
-        $twig_ext = static::$kernel->getContainer()->get('hostnet_webpack.bridge.twig_extension');
-
-        $this->assertEquals('/bundles/henk.png', $twig_ext->webpackPublic('henk.png'));
-    }
-
-    public function envProvider()
-    {
-        return [['dev'], ['test']];
-    }
 
     public function testDevCollector()
     {


### PR DESCRIPTION
Updated the documentation, added an additional test and fixed any BC issues from before. It's now enforced that the `path` ends with the part of the `public_path`.