### PR TITLE
Added ability to register extensions outside the bundle

### DIFF
--- a/src/Bundle/DependencyInjection/WebpackCompilerPass.php
+++ b/src/Bundle/DependencyInjection/WebpackCompilerPass.php
@@ -1,9 +1,9 @@
 <?php
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Harold Iedema <hiedema@hostnet.nl>
@@ -67,6 +67,12 @@ class WebpackCompilerPass implements CompilerPassInterface
             ->getDefinition('hostnet_webpack.bridge.compiler_process')
             ->replaceArgument(0, $config['node']['binary'] . ' ' . $webpack)
             ->replaceArgument(1, $container->getParameter('kernel.cache_dir'));
+
+        $builder_definition   = $container->getDefinition('hostnet_webpack.bridge.config_generator');
+        $config_extension_ids = array_keys($container->findTaggedServiceIds('hostnet_webpack.config_extension'));
+        foreach ($config_extension_ids as $id) {
+            $builder_definition->addMethodCall('addExtension', [new Reference($id)]);
+        }
 
         // Unfortunately, we need to specify some additional environment variables to pass to the compiler process. We
         // need this because there is a big chance that populating the $_ENV variable is disabled on most machines.

--- a/src/Bundle/DependencyInjection/WebpackExtension.php
+++ b/src/Bundle/DependencyInjection/WebpackExtension.php
@@ -7,7 +7,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Class WebpackExtension
@@ -29,7 +28,6 @@ class WebpackExtension extends Extension
         }
 
         // Retrieve all configuration entities
-        $builder_definition   = $container->getDefinition('hostnet_webpack.bridge.config_generator');
         $config_extension_ids = array_keys($container->findTaggedServiceIds('hostnet_webpack.config_extension'));
         $config_definitions   = [];
 
@@ -49,7 +47,6 @@ class WebpackExtension extends Extension
         // Parse application config into the config generator
         foreach ($config_definitions as $id => $definition) {
             /* @var $definition Definition */
-            $builder_definition->addMethodCall('addExtension', [new Reference($id)]);
             $definition->addArgument($config);
         }
 

--- a/src/Component/Configuration/CodeBlockProviderInterface.php
+++ b/src/Component/Configuration/CodeBlockProviderInterface.php
@@ -1,0 +1,12 @@
+<?php
+namespace Hostnet\Component\Webpack\Configuration;
+
+interface CodeBlockProviderInterface
+{
+    /**
+     * Returns the CodeBlock for this plugin.
+     *
+     * @return CodeBlock[]
+     */
+    public function getCodeBlocks();
+}

--- a/src/Component/Configuration/ConfigExtensionInterface.php
+++ b/src/Component/Configuration/ConfigExtensionInterface.php
@@ -6,7 +6,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 /**
  * @author Harold Iedema <hiedema@hostnet.nl>
  */
-interface ConfigExtensionInterface
+interface ConfigExtensionInterface extends CodeBlockProviderInterface
 {
     /**
      * Applies plugin-specific configuration to the TreeBuilder used to parse configuration from the application. This
@@ -19,11 +19,4 @@ interface ConfigExtensionInterface
      * @return string
      */
     public static function applyConfiguration(NodeBuilder $node_builder);
-
-    /**
-     * Returns the CodeBlock for this plugin.
-     *
-     * @return CodeBlock[]
-     */
-    public function getCodeBlocks();
 }

--- a/src/Component/Configuration/ConfigGenerator.php
+++ b/src/Component/Configuration/ConfigGenerator.php
@@ -12,10 +12,10 @@ class ConfigGenerator
     private $blocks;
 
     /**
-     * @param  ConfigExtensionInterface $entity
+     * @param  CodeBlockProviderInterface $entity
      * @return ConfigGenerator
      */
-    public function addExtension(ConfigExtensionInterface $entity)
+    public function addExtension(CodeBlockProviderInterface $entity)
     {
         foreach ($entity->getCodeBlocks() as $block) {
             $this->addBlock($block);

--- a/test/Bundle/DependencyInjection/WebpackCompilerPassTest.php
+++ b/test/Bundle/DependencyInjection/WebpackCompilerPassTest.php
@@ -2,11 +2,14 @@
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 
 use Hostnet\Bundle\WebpackBundle\WebpackBundle;
+use Hostnet\Component\Webpack\Configuration\CodeBlockProviderInterface;
 use Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\BarBundle;
 use Hostnet\Fixture\WebpackBundle\Bundle\FooBundle\FooBundle;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplateFinderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -31,6 +34,13 @@ class WebpackCompilerPassTest extends \PHPUnit_Framework_TestCase
         $container->set('twig', $this->getMock(\Twig_Environment::class));
         $container->set('logger', $this->getMock(LoggerInterface::class));
 
+
+        $container->setDefinition(
+            'webpack_extension',
+            (new Definition(CodeBlockProviderInterface::class))
+                ->addTag('hostnet_webpack.config_extension')
+        );
+
         $bundle->build($container);
 
         $extension->load([
@@ -47,6 +57,9 @@ class WebpackCompilerPassTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($container->hasDefinition('hostnet_webpack.bridge.asset_tracker'));
         $this->assertTrue($container->hasDefinition('hostnet_webpack.bridge.config_generator'));
         $this->assertTrue($container->hasDefinition('hostnet_webpack.bridge.profiler'));
+
+        $method_calls = $container->getDefinition('hostnet_webpack.bridge.config_generator')->getMethodCalls();
+        $this->assertArraySubset([['addExtension', [new Reference('webpack_extension')]]], $method_calls);
     }
 
     /**

--- a/test/Fixture/Bundle/BarBundle/DependencyInjection/BarExtension.php
+++ b/test/Fixture/Bundle/BarBundle/DependencyInjection/BarExtension.php
@@ -1,0 +1,27 @@
+<?php
+namespace Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Loader;
+
+/**
+ * This is the class that loads and manages your bundle configuration
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
+ */
+class BarExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $container->setDefinition(
+            'bar.mock_loader',
+            (new Definition('Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\Loader\MockLoader'))
+                ->addTag('hostnet_webpack.config_extension')
+        );
+    }
+}

--- a/test/Fixture/Bundle/BarBundle/Loader/MockLoader.php
+++ b/test/Fixture/Bundle/BarBundle/Loader/MockLoader.php
@@ -1,0 +1,18 @@
+<?php
+namespace Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\Loader;
+
+use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use Hostnet\Component\Webpack\Configuration\CodeBlockProviderInterface;
+
+class MockLoader implements CodeBlockProviderInterface
+{
+    const BLOCK_CONTENT = 'Webpack mock loader sample block content';
+
+    public $getCodeBlocksCalled = false;
+
+    public function getCodeBlocks()
+    {
+        $this->getCodeBlocksCalled = true;
+        return [(new CodeBlock())->set(CodeBlock::LOADER, self::BLOCK_CONTENT)];
+    }
+}

--- a/test/Functional/ConfigGeneratorTest.php
+++ b/test/Functional/ConfigGeneratorTest.php
@@ -1,0 +1,23 @@
+<?php
+use Hostnet\Component\Webpack\Configuration\ConfigGenerator;
+use Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\Loader\MockLoader;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ConfigGeneratorTest extends KernelTestCase
+{
+    public function testExternalExtensions()
+    {
+        static::bootKernel();
+
+        /** @var $mockLoader MockLoader */
+        $mockLoader = static::$kernel->getContainer()->get('bar.mock_loader');
+
+        /** @var $configGenerator ConfigGenerator */
+        $configGenerator = static::$kernel->getContainer()->get('hostnet_webpack.bridge.config_generator');
+
+        $contiguration = $configGenerator->getConfiguration();
+
+        $this->assertTrue($mockLoader->getCodeBlocksCalled);
+        $this->assertContains(MockLoader::BLOCK_CONTENT, $contiguration);
+    }
+}


### PR DESCRIPTION
Moved `addMethodCall` from `Extension` to `CompilerPass` as it accesses whole container.
Split interface as one of the methods is used only inside the bundle.

This does not allow to configure the extensions inside the bundle configuration itself, but I don't think this would be a good practice, as several other bundles could register same extension names etc. (for example few extra bundles, first one with `raw` and `file`, another one with `raw` and `sass`).

Current usage: just define service as usual in your own bundle, possibly providing configuration values in `config.yml` under your extension key. Tag it with `hostnet_webpack.config_extension`.