### PR TITLE
differentiate fonts from images

### DIFF
--- a/src/Component/Configuration/Loader/UrlLoader.php
+++ b/src/Component/Configuration/Loader/UrlLoader.php
@@ -29,7 +29,8 @@ final class UrlLoader implements LoaderInterface, ConfigExtensionInterface
                 ->addDefaultsIfNotSet()
                 ->children()
                     ->scalarNode('limit')->defaultValue(1000)->end()
-                    ->scalarNode('extensions')->defaultValue('png,gif,jpg,jpeg,svg,woff,woff2,eot,ttf')->end()
+                    ->scalarNode('font_extensions')->defaultValue('svg,woff,woff2,eot,ttf')->end()
+                    ->scalarNode('image_extensions')->defaultValue('png,gif,jpg,jpeg')->end()
                 ->end()
             ->end();
     }
@@ -41,13 +42,35 @@ final class UrlLoader implements LoaderInterface, ConfigExtensionInterface
             return [new CodeBlock()];
         }
 
-        $extensions = str_replace([' ', ','], ['', '|'], $this->config['extensions']);
-        $limit      = $this->config['limit'];
+        $limit            = $this->config['limit'];
+        $image_code_block = [];
+        $font_code_block  = [];
 
-        return [(new CodeBlock())->set(CodeBlock::LOADER, [sprintf(
-            '{ test: /\.(%s)$/, loader: \'url-loader?limit=%d&name=[name]-[hash].[ext]\' }',
-            $extensions,
-            $limit
-        )])];
+        if (isset($this->config['font_extensions'])) {
+            $font_extensions = explode(',', $this->config['font_extensions']);
+
+            foreach ($font_extensions as $font) {
+                $font_code_block[] = (new CodeBlock())->set(CodeBlock::LOADER, [sprintf(
+                    '{ test: /\.%s(\?v=\d+\.\d+\.\d+)?$/, loader: \'url-loader?limit=%d&name=[name]-[hash].[ext]\' }',
+                    $font,
+                    $limit
+                )]);
+            }
+        }
+
+        if (isset($this->config['image_extensions'])) {
+            $image_extensions = str_replace([' ', ','], ['', '|'], $this->config['image_extensions']);
+
+            $image_code_block = [(new CodeBlock())->set(CodeBlock::LOADER, [sprintf(
+                '{ test: /\.(%s)$/, loader: \'url-loader?limit=%d&name=[name]-[hash].[ext]\' }',
+                $image_extensions,
+                $limit
+            )])];
+        }
+
+        return array_merge(
+            $image_code_block,
+            $font_code_block
+        );
     }
 }

--- a/test/Component/Configuration/Loader/UrlLoaderTest.php
+++ b/test/Component/Configuration/Loader/UrlLoaderTest.php
@@ -7,6 +7,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 /**
  * @covers Hostnet\Component\Webpack\Configuration\Loader\UrlLoader
  * @author Harold Iedema <hiedema@hostnet.nl>
+ * @author Guillaume Cavana <guillaume.cavana@gmail.com>
  */
 class UrlLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -19,8 +20,9 @@ class UrlLoaderTest extends \PHPUnit_Framework_TestCase
         $node->end();
 
         $config = $tree->buildTree()->finalize([]);
-
         $this->assertArrayHasKey('url', $config);
+        $this->assertArrayHasKey('font_extensions', $config['url']);
+        $this->assertArrayHasKey('image_extensions', $config['url']);
         $this->assertArrayHasKey('enabled', $config['url']);
     }
 
@@ -32,11 +34,21 @@ class UrlLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($block->has(CodeBlock::LOADER));
     }
 
-    public function testGetCodeBlock()
+    public function testGetFontExtensionCodeBlock()
     {
-        $config = new UrlLoader(['loaders' => ['url' => ['enabled' => true, 'extensions' => 'png', 'limit' => 100]]]);
+        $config = new UrlLoader(['loaders' => ['url' => ['enabled' => true, 'font_extensions' => 'svg,woff', 'limit' => 100]]]);
         $block  = $config->getCodeBlocks()[0];
 
+        $this->assertCount(2, $config->getCodeBlocks());
+        $this->assertTrue($block->has(CodeBlock::LOADER));
+    }
+
+    public function testGetImageExtensionCodeBlock()
+    {
+        $config = new UrlLoader(['loaders' => ['url' => ['enabled' => true, 'image_extensions' => 'png', 'limit' => 100]]]);
+        $block  = $config->getCodeBlocks()[0];
+
+        $this->assertCount(1, $config->getCodeBlocks());
         $this->assertTrue($block->has(CodeBlock::LOADER));
     }
 }


### PR DESCRIPTION
I think we need to make a difference between images and fonts because in some font framework like font awesome they have something like `eot?v=23` in all assets.