### PR TITLE
Loaders are now guard claused and fixed readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,6 @@ Enables loading CSS files.
 webpack:
     loaders:
         css:
-            enabled: true
             filename: '[name].css'
             all_chunks: true
 ```
@@ -422,11 +421,10 @@ This plugin shares the exact same configuration settings as the CSS loader.
 
 > You need the `less-loader`, `css-loader` and `style-loader` node modules for this to work.
 
-```webpack
+```yaml
 webpack:
     loaders:
        less:
-           enabled: true
            filename: '[name].css'
            all_chunks: true
 ```
@@ -439,11 +437,10 @@ This plugin shares the exact same configuration settings as the CSS loader.
 
 > You need the `sass-loader`, `css-loader` and `style-loader` node modules for this to work.
 
-```webpack
+```yaml
 webpack:
     loaders:
        sass:
-           enabled: true
            filename: '[name].css'
            all_chunks: true
 ```
@@ -456,8 +453,7 @@ This plugin only has an `enabled` setting. It is disabled by default.
 ```yaml
 webpack:
     loaders:
-       url:
-           enabled: true
+       url: ~
 ```
 
 ### Babel
@@ -471,8 +467,7 @@ you would need to do is gradually rename your jsx files to js files and everythi
 ```yaml
 webpack:
     loaders:
-        babel:
-            enabled: true
+        babel: ~
 ```
 
 ## Plugins

--- a/src/Component/Configuration/Loader/CSSLoader.php
+++ b/src/Component/Configuration/Loader/CSSLoader.php
@@ -37,34 +37,34 @@ final class CSSLoader implements LoaderInterface, ConfigExtensionInterface
     /** {@inheritdoc} */
     public function getCodeBlocks()
     {
-        $config      = $this->config['loaders']['css'];
-        $code_blocks = [];
+        $config = $this->config['loaders']['css'];
 
-        if ($config['enabled'] !== true) {
+        if (! $config['enabled']) {
             return [new CodeBlock()];
         }
 
         if (empty($config['filename'])) {
             // If the filename is not set, apply inline style tags.
-            $code_blocks[] = (new CodeBlock())->set(CodeBlock::LOADER, '{ test: /\.css$/, loader: \'style-loader!css-loader\' }');
-        } else {
-            // If a filename is set, apply the ExtractTextPlugin
-            $fn            = 'fn_extract_text_plugin_css';
-            $code_blocks[] = (new CodeBlock())
-                ->set(CodeBlock::HEADER, 'var '.$fn.' = require("extract-text-webpack-plugin");')
-                ->set(CodeBlock::LOADER, '{ test: /\.css$/, loader: '.$fn.'.extract("css-loader") }')
-                ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. ($config['all_chunks'] ? 'allChunks: true' : '') . '})');
+            return [(new CodeBlock())->set(CodeBlock::LOADER, '{ test: /\.css$/, loader: \'style-loader!css-loader\' }')];
+        }
 
-            // If a common_filename is set, apply the CommonsChunkPlugin.
-            if (! empty($this->config['output']['common_id'])) {
-                $code_blocks[] = (new CodeBlock())
-                    ->set(CodeBlock::PLUGIN, sprintf(
-                        'new %s({name: \'%s\', filename: \'%s\'})',
-                        'webpack.optimize.CommonsChunkPlugin',
-                        $this->config['output']['common_id'],
-                        $this->config['output']['common_id'] . '.js'
-                    ));
-            }
+        // If a filename is set, apply the ExtractTextPlugin
+        $fn          = 'fn_extract_text_plugin_css';
+        $code_blocks = [(new CodeBlock())
+            ->set(CodeBlock::HEADER, 'var ' . $fn . ' = require("extract-text-webpack-plugin");')
+            ->set(CodeBlock::LOADER, '{ test: /\.css$/, loader: '.$fn.'.extract("css-loader") }')
+            ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. ($config['all_chunks'] ? 'allChunks: true' : '') . '})')
+        ];
+
+        // If a common_filename is set, apply the CommonsChunkPlugin.
+        if (! empty($this->config['output']['common_id'])) {
+            $code_blocks[] = (new CodeBlock())
+                ->set(CodeBlock::PLUGIN, sprintf(
+                    'new %s({name: \'%s\', filename: \'%s\'})',
+                    'webpack.optimize.CommonsChunkPlugin',
+                    $this->config['output']['common_id'],
+                    $this->config['output']['common_id'] . '.js'
+                ));
         }
 
         return $code_blocks;

--- a/src/Component/Configuration/Loader/LessLoader.php
+++ b/src/Component/Configuration/Loader/LessLoader.php
@@ -37,8 +37,7 @@ final class LessLoader implements LoaderInterface, ConfigExtensionInterface
     /** {@inheritdoc} */
     public function getCodeBlocks()
     {
-        $config      = $this->config['loaders']['less'];
-        $code_blocks = [];
+        $config = $this->config['loaders']['less'];
 
         if (! $config['enabled']) {
             return [new CodeBlock()];
@@ -46,25 +45,26 @@ final class LessLoader implements LoaderInterface, ConfigExtensionInterface
 
         if (empty($config['filename'])) {
             // If the filename is not set, apply inline style tags.
-            $code_blocks[] = (new CodeBlock())->set(CodeBlock::LOADER, '{ test: /\.less$/, loader: \'style!css!less\' }');
-        } else {
-            // If a filename is set, apply the ExtractTextPlugin
-            $fn            = 'fn_extract_text_plugin_less';
-            $code_blocks[] = (new CodeBlock())
-                ->set(CodeBlock::HEADER, 'var '.$fn.' = require("extract-text-webpack-plugin");')
-                ->set(CodeBlock::LOADER, '{ test: /\.less$/, loader: '.$fn.'.extract("css!less") }')
-                ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. ($config['all_chunks'] ? 'allChunks: true' : '') . '})');
+            return [(new CodeBlock())->set(CodeBlock::LOADER, '{ test: /\.less$/, loader: \'style!css!less\' }')];
+        }
 
-            // If a common_filename is set, apply the CommonsChunkPlugin.
-            if (! empty($this->config['output']['common_id'])) {
-                $code_blocks[] = (new CodeBlock())
-                    ->set(CodeBlock::PLUGIN, sprintf(
-                        'new %s({name: \'%s\', filename: \'%s\'})',
-                        'webpack.optimize.CommonsChunkPlugin',
-                        $this->config['output']['common_id'],
-                        $this->config['output']['common_id'] . '.js'
-                    ));
-            }
+        // If a filename is set, apply the ExtractTextPlugin
+        $fn          = 'fn_extract_text_plugin_less';
+        $code_blocks = [(new CodeBlock())
+            ->set(CodeBlock::HEADER, 'var ' . $fn . ' = require("extract-text-webpack-plugin");')
+            ->set(CodeBlock::LOADER, '{ test: /\.less$/, loader: '.$fn.'.extract("css!less") }')
+            ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. ($config['all_chunks'] ? 'allChunks: true' : '') . '})')
+        ];
+
+        // If a common_filename is set, apply the CommonsChunkPlugin.
+        if (! empty($this->config['output']['common_id'])) {
+            $code_blocks[] = (new CodeBlock())
+                ->set(CodeBlock::PLUGIN, sprintf(
+                    'new %s({name: \'%s\', filename: \'%s\'})',
+                    'webpack.optimize.CommonsChunkPlugin',
+                    $this->config['output']['common_id'],
+                    $this->config['output']['common_id'] . '.js'
+                ));
         }
 
         return $code_blocks;

--- a/src/Component/Configuration/Loader/SassLoader.php
+++ b/src/Component/Configuration/Loader/SassLoader.php
@@ -37,8 +37,7 @@ final class SassLoader implements LoaderInterface, ConfigExtensionInterface
     /** {@inheritdoc} */
     public function getCodeBlocks()
     {
-        $config      = $this->config['loaders']['sass'];
-        $code_blocks = [];
+        $config = $this->config['loaders']['sass'];
 
         if (! $config['enabled']) {
             return [new CodeBlock()];
@@ -46,25 +45,26 @@ final class SassLoader implements LoaderInterface, ConfigExtensionInterface
 
         if (empty($config['filename'])) {
             // If the filename is not set, apply inline style tags.
-            $code_blocks[] = (new CodeBlock())->set(CodeBlock::LOADER, '{ test: /\.scss$/, loader: \'style!css!sass\' }');
-        } else {
-            // If a filename is set, apply the ExtractTextPlugin
-            $fn            = 'fn_extract_text_plugin_sass';
-            $code_blocks[] = (new CodeBlock())
-                ->set(CodeBlock::HEADER, 'var ' . $fn . ' = require("extract-text-webpack-plugin");')
-                ->set(CodeBlock::LOADER, '{ test: /\.scss$/, loader: '.$fn.'.extract("css!sass") }')
-                ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. ($config['all_chunks'] ? 'allChunks: true' : '') . '})');
+            return [(new CodeBlock())->set(CodeBlock::LOADER, '{ test: /\.scss$/, loader: \'style!css!sass\' }')];
+        }
 
-            // If a common_filename is set, apply the CommonsChunkPlugin.
-            if (! empty($this->config['output']['common_id'])) {
-                $code_blocks[] = (new CodeBlock())
-                    ->set(CodeBlock::PLUGIN, sprintf(
-                        'new %s({name: \'%s\', filename: \'%s\'})',
-                        'webpack.optimize.CommonsChunkPlugin',
-                        $this->config['output']['common_id'],
-                        $this->config['output']['common_id'] . '.js'
-                    ));
-            }
+        // If a filename is set, apply the ExtractTextPlugin
+        $fn          = 'fn_extract_text_plugin_sass';
+        $code_blocks = [(new CodeBlock())
+            ->set(CodeBlock::HEADER, 'var ' . $fn . ' = require("extract-text-webpack-plugin");')
+            ->set(CodeBlock::LOADER, '{ test: /\.scss$/, loader: '.$fn.'.extract("css!sass") }')
+            ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. ($config['all_chunks'] ? 'allChunks: true' : '') . '})')
+        ];
+
+        // If a common_filename is set, apply the CommonsChunkPlugin.
+        if (! empty($this->config['output']['common_id'])) {
+            $code_blocks[] = (new CodeBlock())
+                ->set(CodeBlock::PLUGIN, sprintf(
+                    'new %s({name: \'%s\', filename: \'%s\'})',
+                    'webpack.optimize.CommonsChunkPlugin',
+                    $this->config['output']['common_id'],
+                    $this->config['output']['common_id'] . '.js'
+                ));
         }
 
         return $code_blocks;


### PR DESCRIPTION
 - Replace some "\`\`\`webpack" by "\`\`\`yaml" to fix the highlight in readme.md
 - Removed `enabled: true` where possible
 - CSS/LESS/SASS loaders are now guard clause (still need to fix code duplication)