### PR TITLE
[WIP] Added uglifyjs as plugin

### DIFF
--- a/src/Bundle/Resources/config/plugins.yml
+++ b/src/Bundle/Resources/config/plugins.yml
@@ -4,7 +4,13 @@ services:
         class: Hostnet\Component\Webpack\Configuration\Plugin\DefinePlugin
         tags:
             - { name: hostnet_webpack.config_extension }
+
     hostnet_webpack.plugin.provide:
         class: Hostnet\Component\Webpack\Configuration\Plugin\ProvidePlugin
+        tags:
+            - { name: hostnet_webpack.config_extension }
+
+    hostnet_webpack.plugin.uglifyjs:
+        class: Hostnet\Component\Webpack\Configuration\Plugin\UglifyJsPlugin
         tags:
             - { name: hostnet_webpack.config_extension }

--- a/src/Component/Configuration/Plugin/UglifyJsPlugin.php
+++ b/src/Component/Configuration/Plugin/UglifyJsPlugin.php
@@ -1,0 +1,44 @@
+<?php
+namespace Hostnet\Component\Webpack\Configuration\Plugin;
+
+use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use Hostnet\Component\Webpack\Configuration\ConfigExtensionInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+/**
+ * https://github.com/webpack/docs/wiki/list-of-plugins#uglifyjsplugin
+ *
+ * @author Iltar van der Berg <ivanderberg@hostnet.nl>
+ */
+final class UglifyJsPlugin implements PluginInterface, ConfigExtensionInterface
+{
+    /**
+     * @var string
+     */
+    private $config;
+
+    /**
+     * @param array $config
+     */
+    public function __construct(array $config = [])
+    {
+        $this->config = isset($config['plugins']['uglifyjs']) ? $config['plugins']['uglifyjs'] : null;
+    }
+
+    /** {@inheritdoc} */
+    public static function applyConfiguration(NodeBuilder $node_builder)
+    {
+        $node_builder->scalarNode('uglifyjs')->end();
+    }
+
+    /** {@inheritdoc} */
+    public function getCodeBlocks()
+    {
+        if (null === $this->config) {
+            return [];
+        }
+
+        return [(new CodeBlock())
+            ->set(CodeBlock::PLUGIN, sprintf('new %s(%s)', 'webpack.optimize.UglifyJsPlugin', $this->config))];
+    }
+}

--- a/src/Component/Configuration/Plugin/UglifyJsPlugin.php
+++ b/src/Component/Configuration/Plugin/UglifyJsPlugin.php
@@ -6,12 +6,34 @@ use Hostnet\Component\Webpack\Configuration\ConfigExtensionInterface;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 /**
- * https://github.com/webpack/docs/wiki/list-of-plugins#uglifyjsplugin
+ * @see https://github.com/webpack/docs/wiki/list-of-plugins#uglifyjsplugin
+ * @see http://lisperator.net/uglifyjs/compress
  *
  * @author Iltar van der Berg <ivanderberg@hostnet.nl>
  */
 final class UglifyJsPlugin implements PluginInterface, ConfigExtensionInterface
 {
+    private static $config_map = [
+        ['sequences', true, 'join consecutive statemets with the "comma operator"'],
+        ['properties', true, 'optimize property access: a["foo"] → a.foo'],
+        ['dead_code', true, 'discard unreachable code'],
+        ['drop_debugger', true, 'discard "debugger" statements'],
+        ['unsafe', false, 'some unsafe optimizations'],
+        ['conditionals', true, 'optimize if-s and conditional expressions'],
+        ['comparisons', true, 'optimize comparisons'],
+        ['evaluate', true, 'evaluate constant expressions'],
+        ['booleans', true, 'optimize boolean expressions'],
+        ['loops', true, 'optimize loops'],
+        ['unused', true, 'drop unused variables/functions'],
+        ['hoist_funs', true, 'hoist function declarations'],
+        ['hoist_vars', false, 'hoist variable declarations'],
+        ['if_return', true, 'optimize if-s followed by return/continue'],
+        ['join_vars', true, 'join var declarations'],
+        ['cascade', true, 'try to cascade `right` into `left` in sequences'],
+        ['side_effects', true, 'drop side-effect-free statements'],
+        ['warnings', true, 'warn about potentially dangerous optimizations/code'],
+    ];
+
     /**
      * @var string
      */
@@ -22,23 +44,90 @@ final class UglifyJsPlugin implements PluginInterface, ConfigExtensionInterface
      */
     public function __construct(array $config = [])
     {
-        $this->config = isset($config['plugins']['uglifyjs']) ? $config['plugins']['uglifyjs'] : null;
+        $this->config = isset($config['plugins']['uglifyjs'])  ? $config['plugins']['uglifyjs'] : [];
     }
 
     /** {@inheritdoc} */
     public static function applyConfiguration(NodeBuilder $node_builder)
     {
-        $node_builder->scalarNode('uglifyjs')->end();
+        $uglify = $node_builder
+            ->arrayNode('uglifyjs')
+            ->canBeEnabled()
+                ->children();
+
+        $compress = $uglify
+            ->arrayNode('compress')
+                ->cannotBeEmpty()
+                ->addDefaultsIfNotSet()
+                ->children();
+
+        foreach (self::$config_map as list ($option, $default, $info)) {
+            $compress
+                ->booleanNode($option)
+                    ->defaultValue($default)
+                    ->info($info)
+                ->end();
+        }
+
+        $compress
+            ->arrayNode('global_defs')
+                ->info('global definition')
+                ->prototype('scalar')
+                ->end()
+            ->end();
+
+        $uglify
+            ->arrayNode('mangle_except')
+                ->defaultValue(['$super', '$', 'exports', 'require'])
+                ->info('Variable names to not mangle')
+                ->prototype('scalar')
+            ->end();
+
+        $uglify
+            ->booleanNode('source_map')
+                ->defaultTrue()
+                ->info('The plugin uses SourceMaps to map error message locations to modules. This slows down the compilation')
+            ->end();
+
+        $uglify
+            ->scalarNode('test')
+                ->defaultValue('/\.js($|\?)/i')
+                ->info('RegExp to filter processed files')
+            ->end();
+
+        $uglify
+            ->booleanNode('minimize')
+                ->defaultTrue()
+                ->info('Whether to minimize or not')
+            ->end();
     }
 
     /** {@inheritdoc} */
     public function getCodeBlocks()
     {
-        if (null === $this->config) {
+        if (empty($this->config) || !$this->config['enabled']) {
             return [];
         }
 
+        $compress   = json_encode($this->config['compress']);
+        $source_map = json_encode($this->config['source_map']);
+        $test       = $this->config['test'];
+        $minimize   = json_encode($this->config['minimize']);
+        $mangle     = !empty($this->config['mangle_except'])
+            ? '{except:' . json_encode($this->config['mangle_except']) . '}'
+            : 'false';
+
+        $config = <<<CONFIG
+{
+    compress: $compress,
+    mangle: $mangle,
+    sourceMap: $source_map,
+    test: $test,
+    minimize: $minimize
+}
+CONFIG;
+
         return [(new CodeBlock())
-            ->set(CodeBlock::PLUGIN, sprintf('new %s(%s)', 'webpack.optimize.UglifyJsPlugin', $this->config))];
+            ->set(CodeBlock::PLUGIN, sprintf('new %s(%s)', 'webpack.optimize.UglifyJsPlugin', $config))];
     }
 }

--- a/test/Fixture/config/config.yml
+++ b/test/Fixture/config/config.yml
@@ -33,10 +33,32 @@ webpack:
         provides:
             '$': 'jquery'
             'jQuery': 'jquery'
-        uglifyjs: >
-            {
-                compress: { warnings: %show_warnings_in_uglify% }
-            }
+        uglifyjs:
+            compress:
+                sequences: ~
+                properties: ~
+                dead_code: ~
+                drop_debugger: ~
+                unsafe: ~
+                conditionals: ~
+                comparisons: ~
+                evaluate: ~
+                booleans: ~
+                loops: ~
+                unused: ~
+                hoist_funs: ~
+                hoist_vars: ~
+                if_return: ~
+                join_vars: ~
+                cascade: ~
+                side_effects: ~
+                warnings: ~
+                global_defs:
+                    DEBUG: false
+            test: /\.js($|\?)/i
+            mangle_except: ~
+            minimize: ~
+
 
 monolog:
     handlers:

--- a/test/Fixture/config/config.yml
+++ b/test/Fixture/config/config.yml
@@ -1,3 +1,6 @@
+parameters:
+    show_warnings_in_uglify: 'true'
+
 framework:
     secret: test
     templating:
@@ -30,7 +33,10 @@ webpack:
         provides:
             '$': 'jquery'
             'jQuery': 'jquery'
-
+        uglifyjs: >
+            {
+                compress: { warnings: %show_warnings_in_uglify% }
+            }
 
 monolog:
     handlers:


### PR DESCRIPTION
This PR adds the uglifyjs plugin, but is not finished yet. Currently the option simply accepts a big string which is inserted directly in the constructor of the plugin when configuring webpack. Ideally I would add the options as an array so we can pre-validate and make sure it's correctly configured but I can't find anything decent for a full configuration as documentation is severely lacking. 

From testing it proves that this plugin minimizes both js and css. I have not yet tried sourcemaps but the option exists.

- [x] Configuration options to be defined in `Configuration.php`
- [x] ~~Add additional tests to verify the plugin is working properly~~ unit-test makes no sense

/cc @haroldiedema maybe there's another solution?