### PR TITLE
Added a function to retrieve common id js

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,18 @@ webpack:
         common_id: 'shared'
 ```
 
+In your templates you will be able to retrieve the path to your common javascript file via `webpack_common_js()` and 
+`webpack_common_css()`.
+
+```twig
+<script src="{{ webpack_common_js() }}"></script>
+<link rel="stylesheet" href="{{ webpack_common_css() }}">
+
+{# will give the following output based on output.common_id #}
+<script src="/compiled/shared.js"></script>
+<link rel="stylesheet" href="/compiled/shared.css">
+```
+
 ### Asset output directories
 
 - Dumped assets from the "public" directory are symlinked or copied to the `<output.dump_dir>` directory.

--- a/src/Bundle/DependencyInjection/WebpackCompilerPass.php
+++ b/src/Bundle/DependencyInjection/WebpackCompilerPass.php
@@ -56,7 +56,9 @@ class WebpackCompilerPass implements CompilerPassInterface
             ->getDefinition('hostnet_webpack.bridge.twig_extension')
             ->replaceArgument(0, $web_dir)
             ->replaceArgument(1, $public_path)
-            ->replaceArgument(2, str_replace($web_dir, '', $dump_path));
+            ->replaceArgument(2, str_replace($web_dir, '', $dump_path))
+            ->replaceArgument(3, sprintf('%s/%s.js', $public_path, $config['output']['common_id']))
+            ->replaceArgument(4, sprintf('%s/%s.css', $public_path, $config['output']['common_id']));
 
         // Ensure webpack is installed in the given (or detected) node_modules directory.
         if (false === ($webpack = realpath($config['node']['node_modules_path'] . '/webpack/bin/webpack.js'))) {

--- a/src/Bundle/Resources/config/webpack.yml
+++ b/src/Bundle/Resources/config/webpack.yml
@@ -78,9 +78,10 @@ services:
             - '' # web_path
             - '' # public_path
             - '' # dump_path
+            - '' # common_js
+            - '' # common_css
         tags:
             - { name: twig.extension }
-
 
     hostnet_webpack.bridge.profiler:
         class: Hostnet\Component\Webpack\Profiler\Profiler

--- a/src/Bundle/Twig/TwigExtension.php
+++ b/src/Bundle/Twig/TwigExtension.php
@@ -26,15 +26,29 @@ class TwigExtension extends \Twig_Extension
     private $dump_path;
 
     /**
+     * @var string
+     */
+    private $common_js;
+
+    /**
+     * @var string
+     */
+    private $common_css;
+
+    /**
      * @param string $web_dir
      * @param string $public_path
      * @param string $dump_path
+     * @param string $common_js
+     * @param string $common_css
      */
-    public function __construct($web_dir, $public_path, $dump_path)
+    public function __construct($web_dir, $public_path, $dump_path, $common_js, $common_css)
     {
         $this->web_dir     = $web_dir;
         $this->public_path = $public_path;
         $this->dump_path   = $dump_path;
+        $this->common_js   = $common_js;
+        $this->common_css  = $common_css;
     }
 
     /** {@inheritdoc} */
@@ -55,6 +69,8 @@ class TwigExtension extends \Twig_Extension
         return [
             new \Twig_SimpleFunction('webpack_asset', [$this, 'webpackAsset']),
             new \Twig_SimpleFunction('webpack_public', [$this, 'webpackPublic']),
+            new \Twig_SimpleFunction('webpack_common_js', [$this, 'webpackCommonJs']),
+            new \Twig_SimpleFunction('webpack_common_css', [$this, 'webpackCommonCss']),
         ];
     }
 
@@ -106,5 +122,25 @@ class TwigExtension extends \Twig_Extension
         }, $url);
 
         return rtrim($public_dir, '/') . '/' . ltrim($url, '/');
+    }
+
+    /**
+     * Example: "<output_path>/<common_id>.js".
+     *
+     * @return string
+     */
+    public function webpackCommonJs()
+    {
+        return $this->common_js;
+    }
+
+    /**
+     * Example: "<output_path>/<common_id>.css".
+     *
+     * @return string
+     */
+    public function webpackCommonCss()
+    {
+        return $this->common_css;
     }
 }

--- a/test/Bundle/Twig/Token/WebpackTokenParserTest.php
+++ b/test/Bundle/Twig/Token/WebpackTokenParserTest.php
@@ -11,7 +11,7 @@ class WebpackTokenParserTest extends \PHPUnit_Framework_TestCase
 {
     public function testParser()
     {
-        $extension = new TwigExtension(__DIR__, '/', '/bundles');
+        $extension = new TwigExtension(__DIR__, '/compiled', '/bundles', '/compiled/shared.js', '/compiled/shared.css');
         $parser    = new WebpackTokenParser($extension);
 
         $this->assertEquals(WebpackTokenParser::TAG_NAME, $parser->getTag());

--- a/test/Bundle/Twig/TwigExtensionTest.php
+++ b/test/Bundle/Twig/TwigExtensionTest.php
@@ -9,12 +9,12 @@ class TwigExtensionTest extends \PHPUnit_Framework_TestCase
 {
     public function testExtension()
     {
-        $extension = new TwigExtension(__DIR__, '/', '/bundles');
+        $extension = new TwigExtension(__DIR__, '/', '/bundles', '/shared.js', '/shared.css');
 
         $this->assertEquals('webpack', $extension->getName());
-        $this->assertCount(2, $extension->getFunctions());
-        $this->assertCount(1, $extension->getTokenParsers());
         $this->assertEquals(['js'  => false, 'css' => false], $extension->webpackAsset('@AppBundle/app.js'));
+        $this->assertEquals('/shared.js', $extension->webpackCommonJs());
+        $this->assertEquals('/shared.css', $extension->webpackCommonCss());
     }
 
     /**
@@ -22,7 +22,7 @@ class TwigExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testAssets($expected, $asset, $web_dir, $dump_path, $public_path)
     {
-        $extension = new TwigExtension($web_dir, $public_path, $dump_path);
+        $extension = new TwigExtension($web_dir, $public_path, $dump_path, '', '');
         $this->assertEquals($expected, $extension->webpackPublic($asset));
     }
 

--- a/test/Fixture/Resources/views/common_id.html.twig
+++ b/test/Fixture/Resources/views/common_id.html.twig
@@ -1,0 +1,2 @@
+<script src="{{ webpack_common_js() }}"></script>
+<script rel="stylesheet" href="{{ webpack_common_css() }}"></script>

--- a/test/Fixture/Resources/views/template.html.twig
+++ b/test/Fixture/Resources/views/template.html.twig
@@ -1,5 +1,4 @@
 {# Method one: webpack_asset. #}
-
 <script src="{{ webpack_asset('@BarBundle/app.js').js }}"></script>
 <link rel="stylesheet" href="{{ webpack_asset('@BarBundle/app.js').css }}">
 

--- a/test/Fixture/config/config.yml
+++ b/test/Fixture/config/config.yml
@@ -15,6 +15,7 @@ webpack:
         path: %kernel.root_dir%/cache/compiled/
         dump_path: %kernel.root_dir%/cache/bundles/
         public_path: /compiled/
+        common_id: shared
     loaders:
        sass:
            filename: '[name].css'

--- a/test/Functional/TwigTest.php
+++ b/test/Functional/TwigTest.php
@@ -1,0 +1,18 @@
+<?php
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\TwigBundle\TwigEngine;
+
+class TwigTest extends KernelTestCase
+{
+    public function testTemplates()
+    {
+        static::bootKernel();
+
+        /* @var $twig_ext TwigEngine */
+        $twig = static::$kernel->getContainer()->get('templating');
+        $html = $twig->render('/common_id.html.twig');
+
+        $this->assertContains('src="/compiled/shared.js"', $html);
+        $this->assertContains('href="/compiled/shared.css"', $html);
+    }
+}


### PR DESCRIPTION
Gives an easier notation for the common js/css. Previously you had to hard-code this in your template but with these functions, twig will do this for you. That means you can use different output directories based on your environment. It's very useful when you want to use less processing in dev (to skip uglifyjs for example).