### PR TITLE
Fixed an issue with mandatory caching

### DIFF
--- a/src/Bundle/CacheWarmer/WebpackCompileCacheWarmer.php
+++ b/src/Bundle/CacheWarmer/WebpackCompileCacheWarmer.php
@@ -61,6 +61,6 @@ class WebpackCompileCacheWarmer implements CacheWarmerInterface
      */
     public function isOptional()
     {
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
This caused every warm-up and compile to fail every first request. Can't find out why because webpack is complaining about files that don't exist while they do.