### PR TITLE
Remove use of 'tracking' cache file, compare the 'compiled'-time vs. resouce change time

### DIFF
--- a/src/Bundle/DependencyInjection/WebpackCompilerPass.php
+++ b/src/Bundle/DependencyInjection/WebpackCompilerPass.php
@@ -34,16 +34,17 @@ class WebpackCompilerPass implements CompilerPassInterface
             $bundle_paths[$name] = realpath(dirname((new \ReflectionClass($class))->getFileName()));
         }
 
-        $asset_tracker->replaceArgument(4, $asset_res_path);
+        $asset_tracker->replaceArgument(3, $asset_res_path);
+        $asset_tracker->replaceArgument(4, $path);
         $asset_tracker->replaceArgument(5, $bundle_paths);
 
         // add all aliases to the tracker
         if (isset($config['resolve']['alias']) && is_array($config['resolve']['alias'])) {
-            foreach ($config['resolve']['alias'] as $alias => $path) {
-                if (!file_exists($path)) {
+            foreach ($config['resolve']['alias'] as $alias_path) {
+                if (!file_exists($alias_path)) {
                     continue;
                 }
-                $asset_tracker->addMethodCall('addPath', [$path]);
+                $asset_tracker->addMethodCall('addPath', [$alias_path]);
             }
         }
 
@@ -73,7 +74,12 @@ class WebpackCompilerPass implements CompilerPassInterface
 
         // Ensure webpack is installed in the given (or detected) node_modules directory.
         if (false === ($webpack = realpath($config['node']['node_modules_path'] . '/webpack/bin/webpack.js'))) {
-            throw new \RuntimeException(sprintf('Webpack is not installed in path "%s".', $config['node']['node_modules_path']));
+            throw new \RuntimeException(
+                sprintf(
+                    'Webpack is not installed in path "%s".',
+                    $config['node']['node_modules_path']
+                )
+            );
         }
 
         $process_definition = $container

--- a/src/Bundle/Resources/config/webpack.yml
+++ b/src/Bundle/Resources/config/webpack.yml
@@ -35,9 +35,9 @@ services:
         arguments:
             - '@hostnet_webpack.bridge.profiler'
             - '@templating.finder'
-            - '%kernel.cache_dir%'
             - '%kernel.root_dir%'
             - '' # asset_path
+            - '' # output dir
             - [] # bundles
 
     hostnet_webpack.bridge.asset_dumper:

--- a/src/Component/Asset/Compiler.php
+++ b/src/Component/Asset/Compiler.php
@@ -104,19 +104,19 @@ class Compiler
         $output = $this->process->getOutput() . $this->process->getErrorOutput();
         $this->profiler->set('compiler.executed', true);
         $this->profiler->set('compiler.last_output', $output);
-        $this->profiler->set('compiler.successful',
+        $this->profiler->set(
+            'compiler.successful',
             strpos($output, 'Error:') === false &&
             strpos($output, 'parse failed') === false
         );
 
-        if ($this->profiler->get('compiler.successful')) {
-            $this->tracker->rebuild();
-        }
-
         // Finally, write some logging for later use.
         file_put_contents($this->cache_dir . DIRECTORY_SEPARATOR . 'webpack.compiler.log', $output);
 
-        $this->profiler->set('compiler.performance.compiler', $this->stopwatch->stop('webpack.compiler')->getDuration());
+        $this->profiler->set(
+            'compiler.performance.compiler',
+            $this->stopwatch->stop('webpack.compiler')->getDuration()
+        );
         $this->profiler->set('compiler.performance.total', $this->stopwatch->stop('webpack.total')->getDuration());
 
         return $output;

--- a/src/Component/Asset/TrackedFiles.php
+++ b/src/Component/Asset/TrackedFiles.php
@@ -1,0 +1,77 @@
+<?php
+namespace Hostnet\Component\Webpack\Asset;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * This class tracks a set of files, and offers a function to see if one of the files is changed after a certain time.
+ */
+class TrackedFiles
+{
+
+    /**
+     * The last modified time for the set of files, in a Unix timestamp.
+     *
+     * @var int
+     */
+    private $modification_time;
+
+    /**
+     * Track a set of paths
+     *
+     * @param array $paths the list of directories or files to track / follow
+     */
+    public function __construct(array $paths)
+    {
+        //Filter out the files, the Finder class can not handle files in the ->in() call.
+        $files = array_filter(
+            $paths,
+            function ($possible_file) {
+                return is_file($possible_file);
+            }
+        );
+
+        //Filter out the directories to be used for searching using the Filter class.
+        $dirs = array_filter(
+            $paths,
+            function ($possible_dir) {
+                return is_dir($possible_dir);
+            }
+        );
+
+        $finder = new Finder();
+
+        //Add the given 'stand-alone-files'
+        $finder->append($files);
+
+        //Add the Directores recursively
+        $finder = $finder->in($dirs);
+
+        //Filter out non readable files
+        $finder = $finder->filter(
+            function (SplFileInfo $finder) {
+                return $finder->isReadable();
+            }
+        );
+
+        //Loop through all the files and save the latest modification time.
+        foreach ($finder->files() as $file) {
+            /*@var $file \SplFileInfo */
+            if ($this->modification_time < $file->getMTime()) {
+                $this->modification_time = $file->getMTime();
+            }
+        }
+    }
+
+    /**
+     * Is one of the Tracked files in this set changed later than the other set.
+     *
+     * @param TrackedFiles $other the other set of files to compare to.
+     * @return boolean true if this set if this set is modified after (later) the other set.
+     */
+    public function modifiedAfter(TrackedFiles $other)
+    {
+        return $this->modification_time > $other->modification_time;
+    }
+}

--- a/test/Component/Asset/CompilerTest.php
+++ b/test/Component/Asset/CompilerTest.php
@@ -33,7 +33,6 @@ class CompilerTest extends \PHPUnit_Framework_TestCase
         $this->tracker->expects($this->once())->method('getTemplates')->willReturn(['foobar']);
         $this->tracker->expects($this->once())->method('getAliases')->willReturn(['@AppBundle' => 'foobar']);
         $this->twig_parser->expects($this->once())->method('findSplitPoints')->willReturn(['@AppBundle/app.js' => 'a']);
-        $this->profiler->expects($this->once())->method('get')->willReturn(true);
 
         (new Compiler(
             $this->profiler,

--- a/test/Component/Asset/TrackedFilesTest.php
+++ b/test/Component/Asset/TrackedFilesTest.php
@@ -1,0 +1,163 @@
+<?php
+namespace Hostnet\Component\Webpack\Asset;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * In this unit-test we simulate the 'tracked' files vs. the 'compiled' files with two directories
+ * 'a' for the 'asset's to track' and 'b' the compiled version of those.
+ *
+ * @covers Hostnet\Component\Webpack\Asset\TrackedFiles
+ */
+class TrackedFilesTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Full path to test directory 'a'
+     *
+     * @var string
+     */
+    private $directory_a;
+
+    /**
+     * Full path to test directory 'b'
+     *
+     * @var string
+     */
+    private $directory_b;
+
+    /**
+     * Create test directories a & b
+     *
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->directory_a = tempnam(sys_get_temp_dir(), 'tracked_files_unittest_a');
+        unlink($this->directory_a);
+        mkdir($this->directory_a);
+
+        $this->directory_b = tempnam(sys_get_temp_dir(), 'tracked_files_unittest_b');
+        unlink($this->directory_b);
+        mkdir($this->directory_b);
+
+    }
+
+    /**
+     * Ensure the test directories a & b are removed
+     *
+     * {@inheritDoc}
+     */
+    protected function tearDown()
+    {
+        $fs = new Filesystem();
+        $fs->remove($this->directory_a);
+        $fs->remove($this->directory_b);
+    }
+
+    /**
+     * Test the behavior for empty / no directories
+     */
+    public function testTrackedFilesEmpty()
+    {
+        $t1 = new TrackedFiles([$this->directory_a]);
+        $t2 = new TrackedFiles([$this->directory_b]);
+
+        self::assertFalse($t1->modifiedAfter($t2));
+        self::assertFalse($t2->modifiedAfter($t1));
+
+        self::assertFalse($t1->modifiedAfter($t1));
+        self::assertFalse($t2->modifiedAfter($t2));
+    }
+
+    /**
+     * What happens when a file is added after 'compilation'
+     */
+    public function testAdd()
+    {
+        $time = time();
+
+        $file = tempnam($this->directory_a, 'tracked_files_unittest_a_file1');
+        touch($file, $time - 100);
+        $file = tempnam($this->directory_b, 'tracked_files_unittest_b_file1');
+        touch($file, $time - 50);
+        $file = tempnam($this->directory_a, 'tracked_files_unittest_a_file2');
+        touch($file, $time);
+
+
+        $t1 = new TrackedFiles([$this->directory_a]);
+        $t2 = new TrackedFiles([$this->directory_b]);
+
+        self::assertTrue($t1->modifiedAfter($t2));
+        self::assertFalse($t2->modifiedAfter($t1));
+    }
+
+    /**
+     * What happens when a file is removed after 'compilation'
+     */
+    public function testDel()
+    {
+
+        $time = time();
+
+        $file1 = tempnam($this->directory_a, 'tracked_files_unittest_a_file1');
+        touch($file1, $time - 100);
+        $file2 = tempnam($this->directory_b, 'tracked_files_unittest_b_file1');
+        touch($file2, $time - 50);
+        $file3 = tempnam($this->directory_a, 'tracked_files_unittest_a_file2');
+        touch($file3, $time);
+
+        unlink($file3);
+
+        $t1 = new TrackedFiles([$this->directory_a]);
+        $t2 = new TrackedFiles([$this->directory_b]);
+
+        self::assertFalse($t1->modifiedAfter($t2));
+        self::assertTrue($t2->modifiedAfter($t1));
+
+    }
+
+    /**
+     * What happens when a file is modified before 'compilation'
+     */
+    public function testModifyBefore()
+    {
+        $time = time();
+
+        $file = tempnam($this->directory_a, 'tracked_files_unittest_a_file1');
+        touch($file, $time - 100);
+        $file = tempnam($this->directory_b, 'tracked_files_unittest_b_file1');
+        touch($file, $time - 50);
+        $file = tempnam($this->directory_a, 'tracked_files_unittest_a_file2');
+        touch($file, $time-200);
+
+
+        $t1 = new TrackedFiles([$this->directory_a]);
+        $t2 = new TrackedFiles([$this->directory_b]);
+
+        self::assertFalse($t1->modifiedAfter($t2));
+        self::assertTrue($t2->modifiedAfter($t1));
+    }
+
+    /**
+     * What happens when a file is modified after 'compilation'
+     */
+    public function testModifyAfter()
+    {
+        $time = time();
+
+        $file = tempnam($this->directory_a, 'tracked_files_unittest_a_file1');
+        touch($file, $time - 100);
+        $file = tempnam($this->directory_b, 'tracked_files_unittest_b_file1');
+        touch($file, $time - 50);
+        $file = tempnam($this->directory_a, 'tracked_files_unittest_a_file2');
+        touch($file, $time);
+
+
+        $t1 = new TrackedFiles([$this->directory_a]);
+        $t2 = new TrackedFiles([$this->directory_b]);
+
+        self::assertTrue($t1->modifiedAfter($t2));
+        self::assertFalse($t2->modifiedAfter($t1));
+    }
+}

--- a/test/Component/Asset/TrackerTest.php
+++ b/test/Component/Asset/TrackerTest.php
@@ -3,7 +3,8 @@ namespace Hostnet\Component\Webpack\Asset;
 
 use Hostnet\Component\Webpack\Profiler\Profiler;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplateFinderInterface;
-use Symfony\Component\Templating\TemplateReference;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Templating\TemplateReferenceInterface;
 
 /**
  * @covers \Hostnet\Component\Webpack\Asset\Tracker
@@ -11,75 +12,270 @@ use Symfony\Component\Templating\TemplateReference;
  */
 class TrackerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testTracker()
+    /**
+     * The root directory of the application a.k.a. %kernel.root_dir%
+     *
+     * @var string
+     */
+    private $root_dir;
+
+    /**
+     * The relative path to the asset direcotry full path = $root_dir . / .$asset_dir
+     *
+     * @var string
+     */
+    private $asset_dir;
+
+    /**
+     * The path the to directory where the output is generated
+     *
+     * @var string
+     */
+    private $output_dir;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
     {
-        $profiler     = new Profiler();
-        $finder       = $this->getMock(TemplateFinderInterface::class);
-        $fixture_path = realpath(__DIR__ . '/../../Fixture');
-        $temp_file    = $fixture_path . '/Bundle/tempfile.txt' ;
-        $temp_file2   = $fixture_path . '/Bundle/tempfile2.txt' ;
-        $temp_file3   = $fixture_path . '/Bundle/tempfile3.txt' ;
-        $tracker      = new Tracker($profiler, $finder, $fixture_path . '/cache', $fixture_path, 'Resources', [
-            'FooBundle' => $fixture_path . '/Bundle/FooBundle',
-            'BarBundle' => $fixture_path . '/Bundle/BarBundle'
-        ]);
-
-        touch($temp_file);
-        $tracker->addPath($temp_file);
-        $tracker->addPath($fixture_path . '/Bundle');
-
-        $finder->expects($this->once())->method('findAllTemplates')->willReturn([
-            new TemplateReference('dont_parse_me', 'php'),
-            new TemplateReference('@FooBundle/foo.html.twig', 'twig'),
-            new TemplateReference('@AcmeBundle/foo.html.twig', 'twig'),
-            new TemplateReference('template.html.twig', 'twig'),
-            new TemplateReference('i_dont_exist', 'twig')
-        ]);
-
-        $this->assertEquals('/i/cant/be/resolved', $tracker->resolveResourcePath('/i/cant/be/resolved'));
-
-        // Start by removing the cache file, if it exists.
-        if (file_exists($fixture_path . '/cache/webpack.asset_tracker.cache')) {
-            unlink($fixture_path . '/cache/webpack.asset_tracker.cache');
-        }
-
-        $this->assertTrue($tracker->isOutdated());
-
-        // Start by rebuilding the cache
-        $tracker->rebuild();
-
-        // Since cache is fresh, isOutdated should return false.
-        $this->assertFalse($tracker->isOutdated());
-
-        // Modify something.
-        touch($temp_file, time() + 1 + mt_rand(1, 100));
-        $this->assertTrue($tracker->isOutdated());
-
-        // Create something
-        $tracker->rebuild();
-        touch($temp_file2);
-        $this->assertTrue($tracker->isOutdated());
-        unlink($temp_file);
-        unlink($temp_file2);
-        touch($temp_file3);
-        $this->assertTrue($tracker->isOutdated());
-        $tracker->rebuild();
-        touch($temp_file, time() + 10);
-        $this->assertTrue($tracker->isOutdated());
-        unlink($temp_file3);
+        $fixture_path     = realpath(__DIR__ . '/../../Fixture');
+        $this->root_dir   = $fixture_path;
+        $this->asset_dir  = 'Resources/assets';
+        $this->output_dir = $fixture_path . '/web/compiled';
     }
 
     /**
+     * The the isOutdated function in case the 'compiled' version is outdated.
+     */
+    public function testIsOutdated()
+    {
+
+        $path = tempnam(sys_get_temp_dir(), 'unittest_tracker_source');
+        unlink($path);
+        mkdir($path);
+
+        $output_directory = tempnam(sys_get_temp_dir(), 'unittest_tracker_output');
+        unlink($output_directory);
+        mkdir($output_directory);
+
+        $time = time();
+
+        $file = tempnam($path, 'unittest_tracker_source_asset');
+        touch($file, $time);
+        $file2 = tempnam($output_directory, 'unittest_tracker_output_compiled');
+        touch($file2, $time - 100);
+
+        $profiler = $this->prophesize(Profiler::class);
+        $profiler->set('tracker.reason', 'One of the tracked files has been modified.')->shouldBeCalled();
+        $profiler->set('bundles', [])->shouldBeCalled();
+        $profiler->set('templates', [])->shouldBeCalled();
+        $finder = $this->prophesize(TemplateFinderInterface::class);
+        $finder->findAllTemplates()->willReturn([]);
+        $tracker = new Tracker(
+            $profiler->reveal(),
+            $finder->reveal(),
+            $this->root_dir,
+            $this->asset_dir,
+            $output_directory
+        );
+        $tracker->addPath($path);
+
+        self::assertTrue($tracker->isOutdated());
+
+        //Cleanup
+        $fs = new Filesystem();
+        $fs->remove($path);
+        $fs->remove($output_directory);
+    }
+
+    /**
+     * The the isOutdated function in case the 'compiled' version is still fresh enough.
+     */
+    public function testIsNotOutdated()
+    {
+        $path = tempnam(sys_get_temp_dir(), 'unittest_tracker_source');
+        unlink($path);
+        mkdir($path);
+
+        $output_directory = tempnam(sys_get_temp_dir(), 'unittest_tracker_output');
+        unlink($output_directory);
+        mkdir($output_directory);
+
+        $time = time();
+
+        $file = tempnam($path, 'unittest_tracker_source_asset');
+        touch($file, $time - 100);
+        $file2 = tempnam($output_directory, 'unittest_tracker_output_compiled');
+        touch($file2, $time);
+
+        $profiler = $this->prophesize(Profiler::class);
+        $profiler->set('tracker.reason', false)->shouldBeCalled();
+        $profiler->set('bundles', [])->shouldBeCalled();
+        $profiler->set('templates', [])->shouldBeCalled();
+
+        $finder = $this->prophesize(TemplateFinderInterface::class);
+        $finder->findAllTemplates()->willReturn([]);
+        $tracker = new Tracker(
+            $profiler->reveal(),
+            $finder->reveal(),
+            $this->root_dir,
+            $this->asset_dir,
+            $output_directory
+        );
+        $tracker->addPath($path);
+
+        self::assertFalse($tracker->isOutdated());
+
+        //Cleanup
+        $fs = new Filesystem();
+        $fs->remove($path);
+        $fs->remove($output_directory);
+    }
+
+    /**
+     * Test the getTemplates function when there are no templates.
+     */
+    public function testGetTemplatesNoTemplates()
+    {
+        $profiler = new Profiler();
+        $finder   = $this->prophesize(TemplateFinderInterface::class);
+        $finder->findAllTemplates()->willReturn([]);
+
+        $tracker = new Tracker(
+            $profiler,
+            $finder->reveal(),
+            $this->root_dir,
+            $this->asset_dir,
+            $this->output_dir
+        );
+        self::assertEmpty($tracker->getTemplates());
+    }
+
+    /**
+     * Test the getTemplates function when the path to the template is not resolvable
+     */
+    public function testGetTemplatesTemplateNotFound()
+    {
+        $profiler = new Profiler();
+        $ref      = $this->prophesize(TemplateReferenceInterface::class);
+        $ref->getPath()->willReturn('/ab/ca/dabra');
+        $ref->get('engine')->willReturn('twig');
+        $finder = $this->prophesize(TemplateFinderInterface::class);
+        $finder->findAllTemplates()->willReturn([$ref->reveal()]);
+
+
+        $tracker = new Tracker(
+            $profiler,
+            $finder->reveal(),
+            $this->root_dir,
+            $this->asset_dir,
+            $this->output_dir
+        );
+        self::assertEmpty($tracker->getTemplates());
+    }
+
+    /**
+     * test the getTempaltes function for 1 template, including duplicate call of function.
+     */
+    public function testGetTemplates()
+    {
+        $profiler = new Profiler();
+        $ref      = $this->prophesize(TemplateReferenceInterface::class);
+        $ref->getPath()->willReturn('assets/base.js');
+        $ref->get('engine')->willReturn('twig');
+        $finder = $this->prophesize(TemplateFinderInterface::class);
+        $finder->findAllTemplates()->willReturn([$ref->reveal()]);
+
+
+        $tracker = new Tracker(
+            $profiler,
+            $finder->reveal(),
+            $this->root_dir,
+            $this->asset_dir,
+            $this->output_dir
+        );
+        self::assertEquals(
+            [$this->root_dir . DIRECTORY_SEPARATOR . $this->asset_dir . DIRECTORY_SEPARATOR . 'base.js'],
+            $tracker->getTemplates()
+        );
+
+        //Calling twice results in same answer
+        self::assertEquals(
+            [$this->root_dir . DIRECTORY_SEPARATOR . $this->asset_dir . DIRECTORY_SEPARATOR . 'base.js'],
+            $tracker->getTemplates()
+        );
+    }
+
+    /**
+     * test resloveResourcePath for a full path.
+     */
+    public function testResolveResourcePathNoBundle()
+    {
+        $profiler = new Profiler();
+        $finder   = $this->prophesize(TemplateFinderInterface::class);
+
+        $tracker = new Tracker(
+            $profiler,
+            $finder->reveal(),
+            $this->root_dir,
+            $this->asset_dir,
+            $this->output_dir
+        );
+        self::assertEquals('/i/m/a/fool', $tracker->resolveResourcePath('/i/m/a/fool'));
+    }
+
+    /**
+     * test resloveResourcePath for a bundle path when bundle is not found.
+     */
+    public function testResolveResourcePathBundleNotFound()
+    {
+        $profiler = new Profiler();
+        $finder   = $this->prophesize(TemplateFinderInterface::class);
+
+        $tracker = new Tracker(
+            $profiler,
+            $finder->reveal(),
+            $this->root_dir,
+            $this->asset_dir,
+            $this->output_dir
+        );
+        self::assertFalse($tracker->resolveResourcePath('@Fool'));
+    }
+
+    /**
+     * test resloveResourcePath for a bundle path when bundle is found.
+     */
+    public function testResolveResourcePathBundle()
+    {
+        $profiler = new Profiler();
+        $finder   = $this->prophesize(TemplateFinderInterface::class);
+
+        $tracker = new Tracker(
+            $profiler,
+            $finder->reveal(),
+            $this->root_dir,
+            $this->asset_dir,
+            $this->output_dir,
+            ['BarBundle' => $this->root_dir . DIRECTORY_SEPARATOR . 'Bundle' . DIRECTORY_SEPARATOR . 'BarBundle']
+        );
+        self::assertEquals(
+            $this->root_dir . DIRECTORY_SEPARATOR .
+            'Bundle' . DIRECTORY_SEPARATOR . 'BarBundle' . DIRECTORY_SEPARATOR . $this->asset_dir,
+            $tracker->resolveResourcePath('@BarBundle')
+        );
+    }
+
+    /**
+     * Test addPath for invalid path.
+     *
      * @expectedException \Symfony\Component\Filesystem\Exception\FileNotFoundException
      * @expectedExceptionMessage File "/i/dont/exist" could not be found.
      */
     public function testAddInvalidPath()
     {
-        $profiler     = new Profiler();
-        $finder       = $this->getMock(TemplateFinderInterface::class);
-        $fixture_path = realpath(__DIR__ . '/../../Fixture');
-        $tracker      = new Tracker($profiler, $finder, $fixture_path . '/cache', $fixture_path, []);
-
+        $profiler = new Profiler();
+        $finder   = $this->getMock(TemplateFinderInterface::class);
+        $tracker  = new Tracker($profiler, $finder, $this->root_dir, $this->asset_dir, $this->output_dir, []);
         $tracker->addPath("/i/dont/exist");
     }
 }

--- a/test/Functional/AssetTest.php
+++ b/test/Functional/AssetTest.php
@@ -49,26 +49,6 @@ class AssetTest extends KernelTestCase
         $this->assertContains('app.henk.css?', (string) $resources['css']);
     }
 
-    public function testAliasAssetTracking()
-    {
-        /** @var $tracker Tracker */
-        $container = static::$kernel->getContainer();
-        $tracker   = $container->get('hostnet_webpack.bridge.asset_tracker');
-        $tracker->rebuild();
-
-        $found = false;
-        foreach ($tracker->getCacheEntries() as $file_name => $timestamp) {
-            // as set under alias "app" in config.yml
-            if (preg_match('~/test/Fixture/Resources/assets/base\.js$~', $file_name)) {
-                $found = true;
-            }
-        }
-
-        if (!$found) {
-            $this->fail('/test/Fixture/Resources/assets/base.js was not found in the tracker cache.');
-        }
-    }
-
     protected function tearDown()
     {
         `rm -rf {$this->compiled}`;

--- a/test/Functional/CompileTest.php
+++ b/test/Functional/CompileTest.php
@@ -32,7 +32,6 @@ class CompileTest extends KernelTestCase
 
         /** @var $tracker Tracker */
         $tracker = static::$kernel->getContainer()->get('hostnet_webpack.bridge.asset_tracker');
-        $tracker->rebuild();
 
         $templates = array_map(array($this, 'relative'), $tracker->getTemplates());
 
@@ -46,7 +45,17 @@ class CompileTest extends KernelTestCase
 
     private function relative($path)
     {
-        return str_replace(str_replace('/test/Fixture', '', $this->normalize(static::$kernel->getContainer()->getParameter('kernel.root_dir'))), '', $this->normalize($path));
+        return str_replace(
+            str_replace(
+                '/test/Fixture',
+                '',
+                $this->normalize(
+                    static::$kernel->getContainer()->getParameter('kernel.root_dir')
+                )
+            ),
+            '',
+            $this->normalize($path)
+        );
     }
 
     private function normalize($path)


### PR DESCRIPTION
Instead of storing and 'tracking' a file with last modified timestamps of all tracked resources, compare all the resouces vs. the compiled time.