### PR TITLE
Add support for include paths config option for node-sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,8 @@ webpack:
        sass:
            filename: '[name].css'
            all_chunks: true
+           include_paths:
+               - [include dirs for node-sass]
 ```
 
 ### URL

--- a/src/Component/Configuration/CodeBlock.php
+++ b/src/Component/Configuration/CodeBlock.php
@@ -34,6 +34,7 @@ namespace Hostnet\Component\Webpack\Configuration;
  *          output : {
  *              << output >>
  *          }
+ *          << root >>
  *      };
  *
  * @author Harold Iedema <hiedema@hostnet.nl>
@@ -48,11 +49,12 @@ class CodeBlock
           PRE_LOADER     = 'pre_loader',
           LOADER         = 'loader',
           POST_LOADER    = 'post_loader',
-          OUTPUT         = 'output';
+          OUTPUT         = 'output',
+          ROOT           = 'root';
 
     // Available types to allow easy validation
     private $types = [
-        'entry', 'header', 'resolve', 'resolve_loader', 'plugin', 'pre_loader', 'loader', 'post_loader', 'output'
+        'entry', 'header', 'resolve', 'resolve_loader', 'plugin', 'pre_loader', 'loader', 'post_loader', 'output', 'root'
     ];
 
     // Chunks collection

--- a/src/Component/Configuration/ConfigGenerator.php
+++ b/src/Component/Configuration/ConfigGenerator.php
@@ -80,7 +80,12 @@ class ConfigGenerator
         $code[] = $tab2 . $this->getChunks(CodeBlock::POST_LOADER, ',' . PHP_EOL . $tab2, ',' . PHP_EOL . $tab2);
         $code[] = $tab1 . ']';
         $code[] = '}';
-        $code[] = '';
+        if (!empty($this->getChunks(CodeBlock::ROOT))) {
+            $code[] = ',';
+            $code[] = $tab1 . $this->getChunks(CodeBlock::ROOT, ',' . PHP_EOL . $tab1, ',' . PHP_EOL . $tab1);
+        } else {
+            $code[] = '';
+        }
         $code[] = '};';
         $code[] = '';
 


### PR DESCRIPTION
I figure this code needs some more love before it's ready to merge, but wanted to get your initial feedback.

Our use case required us to have include paths for scss in order to utilize Foundation.  This updates the SASS filter to have a new include_paths option set in the YAML config that gets passed into node-sass.