### PR TITLE
Update SASS loader to work correctly with both the include_paths and filename options.

### DIFF
--- a/src/Component/Configuration/ConfigGenerator.php
+++ b/src/Component/Configuration/ConfigGenerator.php
@@ -80,11 +80,10 @@ class ConfigGenerator
         $code[] = $tab2 . $this->getChunks(CodeBlock::POST_LOADER, ',' . PHP_EOL . $tab2, ',' . PHP_EOL . $tab2);
         $code[] = $tab1 . ']';
         $code[] = '}';
+        $code[] = '';
         if (!empty($this->getChunks(CodeBlock::ROOT))) {
             $code[] = ',';
             $code[] = $tab1 . $this->getChunks(CodeBlock::ROOT, ',' . PHP_EOL . $tab1, ',' . PHP_EOL . $tab1);
-        } else {
-            $code[] = '';
         }
         $code[] = '};';
         $code[] = '';

--- a/src/Component/Configuration/Loader/SassLoader.php
+++ b/src/Component/Configuration/Loader/SassLoader.php
@@ -42,25 +42,19 @@ final class SassLoader implements LoaderInterface, ConfigExtensionInterface
     {
         $config = $this->config['loaders']['sass'];
 
-        if (! $config['enabled']) {
-            return [new CodeBlock()];
-        }
-
         $block = new CodeBlock;
-        $single = false;
+
+        if (! $config['enabled']) {
+            return [$block];
+        }
 
         if (!empty($config['include_paths'])) {
             $block->set(CodeBlock::ROOT, 'sassLoader: { includePaths: [\'' . implode('\',\'', $config['include_paths']) . '\']}');
-            $single = true;
         }
 
         if (empty($config['filename'])) {
             // If the filename is not set, apply inline style tags.
             $block->set(CodeBlock::LOADER, '{ test: /\.scss$/, loader: \'style!css!sass\' }');
-            $single = true;
-        }
-
-        if ($single) {
             return [$block];
         }
 
@@ -71,6 +65,10 @@ final class SassLoader implements LoaderInterface, ConfigExtensionInterface
             ->set(CodeBlock::LOADER, '{ test: /\.scss$/, loader: '.$fn.'.extract("css!sass") }')
             ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. ($config['all_chunks'] ? 'allChunks: true' : '') . '})')
         ];
+
+        if (!empty($config['include_paths'])) {
+            $code_blocks[0]->set(CodeBlock::ROOT, 'sassLoader: { includePaths: [\'' . implode('\',\'', $config['include_paths']) . '\']}');
+        }
 
         // If a common_filename is set, apply the CommonsChunkPlugin.
         if (! empty($this->config['output']['common_id'])) {

--- a/test/Component/Configuration/ConfigGeneratorTest.php
+++ b/test/Component/Configuration/ConfigGeneratorTest.php
@@ -4,6 +4,7 @@ namespace Hostnet\Component\Webpack\Configuration;
 use Hostnet\Component\Webpack\Configuration\Config\OutputConfig;
 use Hostnet\Component\Webpack\Configuration\Loader\CSSLoader;
 use Hostnet\Component\Webpack\Configuration\Plugin\DefinePlugin;
+use Hostnet\Component\Webpack\Configuration\Loader\SassLoader;
 
 /**
  * @covers \Hostnet\Component\Webpack\Configuration\ConfigGenerator
@@ -46,7 +47,7 @@ class ConfigGeneratorTest extends \PHPUnit_Framework_TestCase
 
         // Add extension
         $config->addExtension(new OutputConfig(['output' => ['path' => 'path/to/output']]));
-        $config->addExtension(new CSSLoader(['loaders' => ['css' => ['enabled' => true, 'filename' => 'foo', 'all_chunks' => true]]]));
+        $config->addExtension(new SassLoader(['loaders' => ['sass' => ['enabled' => true, 'include_paths' => ['path1', 'path2'], 'filename' => 'testfile', 'all_chunks' => true]]]));
 
         $fixture_file = __DIR__ . '/../../Fixture/Component/Configuration/ConfigGenerator.js';
         // file_put_contents($fixture_file, $config->getConfiguration());

--- a/test/Component/Configuration/Loader/SassLoaderTest.php
+++ b/test/Component/Configuration/Loader/SassLoaderTest.php
@@ -40,4 +40,13 @@ class SassLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($block->has(CodeBlock::LOADER));
     }
+
+    public function testGetCodeBlockWithIncludePaths()
+    {
+        $config = new SassLoader(['loaders' => ['sass' => ['enabled' => true, 'include_paths' => ['path1', 'path2'], 'filename' => 'testfile', 'all_chunks' => true]]]);
+        $block  = $config->getCodeBlocks()[0];
+
+        $this->assertTrue($block->has(CodeBlock::ROOT));
+        $this->assertTrue($block->has(CodeBlock::HEADER));
+    }
 }

--- a/test/Fixture/Component/Configuration/ConfigGenerator.js
+++ b/test/Fixture/Component/Configuration/ConfigGenerator.js
@@ -4,7 +4,7 @@ var webpack = require('webpack');
 var a = require("b");
 var preLoader1 = require("pre-loader-1");
 var preLoader2 = require("pre-loader-2");
-var fn_extract_text_plugin_css = require("extract-text-webpack-plugin");
+var fn_extract_text_plugin_sass = require("extract-text-webpack-plugin");
 module.exports = {
 
 entry : {
@@ -34,7 +34,7 @@ resolveLoader : {
 plugins : [
     new webpack.DefinePlugin({"a":"b","b":"c"}), 
     new webpack.DefinePlugin({"c":"d","d":"e"}), 
-    new fn_extract_text_plugin_css("foo", {allChunks: true})
+    new fn_extract_text_plugin_sass("testfile", {allChunks: true})
 ],
 module : {
     preLoaders : [
@@ -43,11 +43,13 @@ module : {
     ],
     loaders : [
         { test: /\.css$/, loader: "style!some-loader" },
-        { test: /\.css$/, loader: fn_extract_text_plugin_css.extract("css-loader") }
+        { test: /\.scss$/, loader: fn_extract_text_plugin_sass.extract("css!sass") }
     ],
     postLoaders : [
         { test: /\.inl$/, loader: "style" }
     ]
 }
 
+,
+    sassLoader: { includePaths: ['path1','path2']}
 };


### PR DESCRIPTION
Sorry I missed this in the previous pull request.  The SASS loader would not operate correctly if both the include_paths and file name option were specified.  This updates the loader to respect both options, if both are passed.