### PR TITLE
Update compile command timeout to 300 seconds.

### DIFF
--- a/src/Component/Asset/Compiler.php
+++ b/src/Component/Asset/Compiler.php
@@ -99,6 +99,7 @@ class Compiler
         );
         $this->profiler->set('compiler.performance.prepare', $this->stopwatch->stop('webpack.prepare')->getDuration());
         $this->stopwatch->start('webpack.compiler');
+        $this->process->setTimeout(300);
         $this->process->run();
 
         $output = $this->process->getOutput() . $this->process->getErrorOutput();


### PR DESCRIPTION
In some cases, Webpack may need to run for longer than the default 60
seconds allowed by Symfony, and would throw an exception if compilation
takes longer.