### PR TITLE
Update README.md to include reference to compile_timeout setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [Shared dependencies](#shared-dependencies)
   - [Asset output directories](#asset-output-directories)
   - [Ideal configuration](#ideal-configuration)
+  - [Compile Timeout](#compile-timeout)
 - [Loaders](#loaders)
   - [CSS](#css)
   - [Less](#less)
@@ -409,6 +410,16 @@ Somewhere in your twig templates
 {% webpack css "@YourBundle/SomeModule.js" %}
     <link rel="stylesheet" href="{{ asset }}">
 {% endwebpack %}
+```
+
+### Compile Timeout
+
+By default, webpack is only given 60 seconds to execute.  In cases where webpack needs more time, you can update the
+`compile_timeout` option.
+
+```yaml
+webpack:
+    compile_timeout: 60
 ```
 
 ## Loaders


### PR DESCRIPTION
Per discussion in Pull Request #71, adding a note in the README for the already existing compile_timeout option.