### PR TITLE
[BC-break] Twig 2.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,7 @@ cache:
 
 matrix:
   include:
-    # Symfony 2.7.0
-#    - php: 5.5
-#      env: COMPOSER_FLAGS="--prefer-lowest"
-    # Symfony 2.8
-#    - php: 5.6
-#      env: SYMFONY_VERSION="2.8.*@dev"
-    # Symfony 3.0
-    - php: 5.6
+    - php: 7.0
       env: DEPS=dev
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
     - php: 7.0
       env: DEPS=dev
 
+env:
+  - COMPOSER_FLAGS="--prefer-lowest"
+
 before_install:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,26 @@ cache:
   directories:
     - "$HOME/.composer/cache"
 
-#php:
-#  - 5.5
-#  - 5.6
-#  - 7.0
-#  - hhvm
+env:
+  - COMPOSER_FLAGS="--prefer-stable"
+
+php:
+    - '7.0'
+    - '7.1'
+    - nightly
 
 matrix:
   include:
     - php: 7.0
-      env: DEPS=dev
-
-env:
-  - COMPOSER_FLAGS="--prefer-lowest"
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.0
+      env: COMPOSER_FLAGS=""
+    - php: 7.1
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.1
+      env: COMPOSER_FLAGS=""
+  allow_failures:
+    - php: nightly
 
 before_install:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Due to some breaking changes in Twig, webpack-bundle 2.0 was released to be made
 To ensure a smooth upgrade, please ensure that you have the following in your project:
 
 - PHP 7.0 or higher
-- Symfony 3.3.2 or higher
-- Twig 2.4.3 or higher
+- Symfony 3.3.0 or higher
+- Twig 2.4.0 or higher
 
 There are no configuration changes made in this version. If your project uses the package versions as mentioned above, 
 you should not run into any issues when upgrading webpack-bundle to 2.0.
@@ -80,7 +80,7 @@ you should not run into any issues when upgrading webpack-bundle to 2.0.
 The following additional changes were made in this version:
 
 - Use PHP 7 strict type declaration
-- Use namespaced Twig classes (e.g. `\Twig\Environemnt` instead of `\Twig_Environment`)
+- Use namespaced Twig classes, which are introduced in Twig 2.4 for future compatibility (e.g. `\Twig\Environemnt` instead of `\Twig_Environment`)
 - Enforce code style using `phpcs` and enforcing the extra ruleset specified by Hostnet.
 - The class `CSSLoader` was renamed to `CssLoader` because our code style rules enforce this.
 - Generated file names for inline javascript/css source are now coming from `TokenStream->getSourceContext()->getName()` instead of `TokenStream->getFilename()`. The latter function was removed from Twig.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 - [Introduction](#introduction)
 - [Installation](#installation)
+- [Upgrading to 2.0](#upgrading-to-2.0)
 - [Quick how-to](#quick-how-to)
 - [Twig tag](#twig-tag)
 - [Configuration](#configuration)
@@ -61,6 +62,28 @@ Once installed, enable the bundle `Hostnet\Bundle\WebpackBundle\WebpackBundle` i
 
 > ___Warning___: In order to have the webpack twig tag detect the compiled files, webpack has to be compiled already. Therefore
 >  it's mandatory to run the compile command `webpack:compile` __before__ the cache warmpup.
+
+
+## Upgrading to 2.0
+
+Due to some breaking changes in Twig, webpack-bundle 2.0 was released to be made compatible with the new twig version.
+
+To ensure a smooth upgrade, please ensure that you have the following in your project:
+
+- PHP 7.0 or higher
+- Symfony 3.3.2 or higher
+- Twig 2.4.3 or higher
+
+There are no configuration changes made in this version. If your project uses the package versions as mentioned above, 
+you should not run into any issues when upgrading webpack-bundle to 2.0.
+ 
+The following additional changes were made in this version:
+
+- Use PHP 7 strict type declaration
+- Use namespaced Twig classes (e.g. `\Twig\Environemnt` instead of `\Twig_Environment`)
+- Enforce code style using `phpcs` and enforcing the extra ruleset specified by Hostnet.
+- The class `CSSLoader` was renamed to `CssLoader` because our code style rules enforce this.
+- Generated file names for inline javascript/css source are now coming from `TokenStream->getSourceContext()->getName()` instead of `TokenStream->getFilename()`. The latter function was removed from Twig.
 
 ## Quick how-to
 

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ webpack:
 
 Loaders allow you to `require` files other than javascript. This package comes with 7 default loaders.
 
- - `CSSLoader`       : include CSS files
+ - `CssLoader`       : include CSS files
  - `UrlLoader`       : include images (converted to base64)
  - `LessLoader`      : include less files.
  - `SassLoader`      : include sass files.

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "twig/twig":              "^2.4.3"
     },
     "require-dev": {
+        "hostnet/phpcs-tool":     "^4.1.4",
         "phpunit/phpunit":        "^6.2.2",
         "symfony/phpunit-bridge": "^3.3.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
     "require": {
         "php":                    "^7.0",
         "symfony/monolog-bundle": "^3.1.0",
-        "symfony/symfony":        "3.3.*,>=3.3.2",
-        "twig/twig":              "^2.4.3"
+        "symfony/symfony":        "^3.3.0",
+        "twig/twig":              "^2.4.0"
     },
     "require-dev": {
-        "hostnet/phpcs-tool":     "^4.1.4",
+        "hostnet/phpcs-tool":     "^5.2.0",
         "phpunit/phpunit":        "^6.2.2",
         "symfony/phpunit-bridge": "^3.3.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,34 +1,34 @@
 {
-    "name"              : "hostnet/webpack-bundle",
-    "description"       : "Integrates Webpack with Symfony2",
-    "authors"           : [{ "name": "Harold Iedema", "email" : "hiedema@hostnet.nl" }],
-    "license"           : "MIT",
-    "type"              : "symfony-bundle",
-    "keywords"          : ["symfony", "webpack", "bundle", "asset", "resources", "javascript", "css", "less", "content"],
-    "require"           : {
-        "php"                          : "^5.5|^7.0",
-        "symfony/symfony"              : "^2.7|^3.0",
-        "symfony/monolog-bundle"       : "^2.7|^3.0",
-        "twig/twig"                    : "^1.18|^2.0"
+    "name":        "hostnet/webpack-bundle",
+    "type":        "symfony-bundle",
+    "description": "Integrates Webpack with Symfony2",
+    "license":     "MIT",
+    "require": {
+        "php":                    "^7.0",
+        "symfony/monolog-bundle": "^3.1.0",
+        "symfony/symfony":        "3.3.*,>=3.3.2",
+        "twig/twig":              "^2.4.3"
     },
-    "require-dev" : {
-        "phpunit/phpunit" : "^4.7|^5.0",
-        "symfony/phpunit-bridge": "^2.7|^3.0"
+    "require-dev": {
+        "phpunit/phpunit":        "^6.2.2",
+        "symfony/phpunit-bridge": "^3.3.2"
     },
-    "autoload" : {
-        "psr-4" : {
-            "Hostnet\\Bundle\\WebpackBundle\\" : "src/Bundle",
-            "Hostnet\\Component\\Webpack\\"    : "src/Component"
+    "autoload": {
+        "psr-4": {
+            "Hostnet\\Bundle\\WebpackBundle\\": "src/Bundle",
+            "Hostnet\\Component\\Webpack\\":    "src/Component"
         }
     },
-    "autoload-dev" : {
-        "psr-4" : {
-            "Hostnet\\Fixture\\WebpackBundle\\" : "test/Fixture",
-            "Hostnet\\Bundle\\WebpackBundle\\"  : "test/Bundle",
-            "Hostnet\\Component\\Webpack\\"     : "test/Component"
+    "autoload-dev": {
+        "psr-4": {
+            "Hostnet\\Fixture\\WebpackBundle\\": "test/Fixture",
+            "Hostnet\\Bundle\\WebpackBundle\\":  "test/Bundle",
+            "Hostnet\\Component\\Webpack\\":     "test/Component"
         }
     },
     "archive": {
-        "exclude": [ "/test" ]
+        "exclude": [
+            "/test"
+        ]
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ruleset name="hostnet/webpack-bundle">
+  <exclude-pattern>test/Fixture/cache/*</exclude-pattern>
+
+  <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+    <exclude-pattern>test/Fixture/TestKernel.php</exclude-pattern>
+  </rule>
+  <rule ref="Hostnet"/>
+</ruleset>

--- a/src/Bundle/CacheWarmer/WebpackCompileCacheWarmer.php
+++ b/src/Bundle/CacheWarmer/WebpackCompileCacheWarmer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\CacheWarmer;
 
 use Hostnet\Component\Webpack\Asset\CacheGuard;

--- a/src/Bundle/CacheWarmer/WebpackCompileCacheWarmer.php
+++ b/src/Bundle/CacheWarmer/WebpackCompileCacheWarmer.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\CacheWarmer;
 

--- a/src/Bundle/Command/CompileCommand.php
+++ b/src/Bundle/Command/CompileCommand.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Command;
 

--- a/src/Bundle/Command/CompileCommand.php
+++ b/src/Bundle/Command/CompileCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Command;
 
 use Hostnet\Component\Webpack\Asset\CacheGuard;

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 
 use Hostnet\Component\Webpack\Configuration\Config\ConfigInterface;

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 

--- a/src/Bundle/DependencyInjection/WebpackCompilerPass.php
+++ b/src/Bundle/DependencyInjection/WebpackCompilerPass.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 

--- a/src/Bundle/DependencyInjection/WebpackCompilerPass.php
+++ b/src/Bundle/DependencyInjection/WebpackCompilerPass.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -66,11 +67,11 @@ class WebpackCompilerPass implements CompilerPassInterface
 
         $container
             ->getDefinition('hostnet_webpack.bridge.twig_extension')
-            ->replaceArgument(0, $web_dir)
-            ->replaceArgument(1, $public_path)
-            ->replaceArgument(2, str_replace($web_dir, '', $dump_path))
-            ->replaceArgument(3, sprintf('%s/%s.js', $public_path, $config['output']['common_id']))
-            ->replaceArgument(4, sprintf('%s/%s.css', $public_path, $config['output']['common_id']));
+            ->replaceArgument(1, $web_dir)
+            ->replaceArgument(2, $public_path)
+            ->replaceArgument(3, str_replace($web_dir, '', $dump_path))
+            ->replaceArgument(4, sprintf('%s/%s.js', $public_path, $config['output']['common_id']))
+            ->replaceArgument(5, sprintf('%s/%s.css', $public_path, $config['output']['common_id']));
 
         // Ensure webpack is installed in the given (or detected) node_modules directory.
         if (false === ($webpack = realpath($config['node']['node_modules_path'] . '/webpack/bin/webpack.js'))) {

--- a/src/Bundle/DependencyInjection/WebpackExtension.php
+++ b/src/Bundle/DependencyInjection/WebpackExtension.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 

--- a/src/Bundle/DependencyInjection/WebpackExtension.php
+++ b/src/Bundle/DependencyInjection/WebpackExtension.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;

--- a/src/Bundle/EventListener/RequestListener.php
+++ b/src/Bundle/EventListener/RequestListener.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\EventListener;
 

--- a/src/Bundle/EventListener/RequestListener.php
+++ b/src/Bundle/EventListener/RequestListener.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\EventListener;
 
 use Hostnet\Component\Webpack\Asset\CacheGuard;

--- a/src/Bundle/Resources/config/loaders.yml
+++ b/src/Bundle/Resources/config/loaders.yml
@@ -1,6 +1,6 @@
 services:
     hostnet_webpack.loader.css:
-        class: Hostnet\Component\Webpack\Configuration\Loader\CSSLoader
+        class: Hostnet\Component\Webpack\Configuration\Loader\CssLoader
         tags:
             - { name: "hostnet_webpack.config_extension" }
     hostnet_webpack.loader.url:

--- a/src/Bundle/Resources/config/webpack.yml
+++ b/src/Bundle/Resources/config/webpack.yml
@@ -77,6 +77,7 @@ services:
     hostnet_webpack.bridge.twig_extension:
         class: Hostnet\Bundle\WebpackBundle\Twig\TwigExtension
         arguments:
+            - "@twig.loader"
             - "" # web_path
             - "" # public_path
             - "" # dump_path

--- a/src/Bundle/Twig/Node/WebpackInlineNode.php
+++ b/src/Bundle/Twig/Node/WebpackInlineNode.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Twig\Node;
 

--- a/src/Bundle/Twig/Node/WebpackInlineNode.php
+++ b/src/Bundle/Twig/Node/WebpackInlineNode.php
@@ -1,10 +1,14 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Twig\Node;
+
+use Twig\Compiler;
+use Twig\Node\Node;
 
 /**
  * @author Yannick de Lange <yannick.l.88@gmail.com>
  */
-class WebpackInlineNode extends \Twig_Node
+class WebpackInlineNode extends Node
 {
     /**
      * @param array  $attributes An array of attributes (should not be nodes)
@@ -17,7 +21,7 @@ class WebpackInlineNode extends \Twig_Node
     }
 
     /** {@inheritdoc} */
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         if (false !== ($file = $this->getAttribute('js_file'))) {
             $compiler

--- a/src/Bundle/Twig/Node/WebpackNode.php
+++ b/src/Bundle/Twig/Node/WebpackNode.php
@@ -1,13 +1,17 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Twig\Node;
+
+use Twig\Compiler;
+use Twig\Node\Node;
 
 /**
  * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class WebpackNode extends \Twig_Node
+class WebpackNode extends Node
 {
     /** {@inheritdoc} */
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         foreach ($this->getAttribute('files') as $file) {
             $compiler->write('$context["asset"] = "'. $file .'";');

--- a/src/Bundle/Twig/Node/WebpackNode.php
+++ b/src/Bundle/Twig/Node/WebpackNode.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Twig\Node;
 

--- a/src/Bundle/Twig/Token/WebpackTokenParser.php
+++ b/src/Bundle/Twig/Token/WebpackTokenParser.php
@@ -1,15 +1,22 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Twig\Token;
 
 use Hostnet\Bundle\WebpackBundle\Twig\Node\WebpackInlineNode;
 use Hostnet\Bundle\WebpackBundle\Twig\Node\WebpackNode;
 use Hostnet\Bundle\WebpackBundle\Twig\TwigExtension;
 use Hostnet\Component\Webpack\Asset\TwigParser;
+use Twig\Extension\ExtensionInterface;
+use Twig\Loader\LoaderInterface;
+use Twig\Parser;
+use Twig\Token;
+use Twig\TokenParser\TokenParserInterface;
+use Twig\TokenStream;
 
 /**
  * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class WebpackTokenParser implements \Twig_TokenParserInterface
+class WebpackTokenParser implements TokenParserInterface
 {
     /**
      * Tag name is declared as constant for easy accessibility by the TwigParser for split-point detection.
@@ -17,7 +24,7 @@ class WebpackTokenParser implements \Twig_TokenParserInterface
     const TAG_NAME = 'webpack';
 
     /**
-     * @var \Twig_Parser
+     * @var Parser
      */
     private $parser;
 
@@ -27,20 +34,27 @@ class WebpackTokenParser implements \Twig_TokenParserInterface
     private $extension;
 
     /**
+     * @var LoaderInterface
+     */
+    private $loader;
+
+    /**
      * @var int[]
      */
     private $inline_blocks = [];
 
     /**
-     * @param TwigExtension $extension
+     * @param ExtensionInterface $extension
+     * @param LoaderInterface    $loader
      */
-    public function __construct(TwigExtension $extension)
+    public function __construct(ExtensionInterface $extension, LoaderInterface $loader)
     {
         $this->extension = $extension;
+        $this->loader    = $loader;
     }
 
     /** {@inheritDoc} */
-    public function setParser(\Twig_Parser $parser)
+    public function setParser(Parser $parser)
     {
         $this->parser = $parser;
     }
@@ -52,13 +66,13 @@ class WebpackTokenParser implements \Twig_TokenParserInterface
     }
 
     /** {@inheritDoc} */
-    public function parse(\Twig_Token $token)
+    public function parse(Token $token)
     {
         $stream = $this->parser->getStream();
         $lineno = $stream->getCurrent()->getLine();
 
         // Export type: "js" or "css"
-        $export_type = $stream->expect(\Twig_Token::NAME_TYPE)->getValue();
+        $export_type = $stream->expect(Token::NAME_TYPE)->getValue();
         if (! in_array($export_type, ['js', 'css', 'inline'])) {
             // This exception will include the template filename by itself.
             throw new \Twig_Error_Syntax(sprintf(
@@ -76,17 +90,16 @@ class WebpackTokenParser implements \Twig_TokenParserInterface
     }
 
     /**
-     * @param \Twig_TokenStream $stream
-     * @param int               $lineno
-     * @param string            $export_type
+     * @param TokenStream $stream
+     * @param int         $lineno
+     * @param string      $export_type
      * @return WebpackNode
-     * @throws \Twig_Error_Syntax
      */
-    private function parseType(\Twig_TokenStream $stream, $lineno, $export_type)
+    private function parseType(TokenStream $stream, $lineno, $export_type)
     {
         $files = [];
-        while (! $stream->isEOF() && ! $stream->getCurrent()->test(\Twig_Token::BLOCK_END_TYPE)) {
-            $asset = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
+        while (! $stream->isEOF() && ! $stream->getCurrent()->test(Token::BLOCK_END_TYPE)) {
+            $asset = $stream->expect(Token::STRING_TYPE)->getValue();
 
             if (false === ($file = $this->extension->webpackAsset($asset)[$export_type])) {
                 continue;
@@ -94,39 +107,37 @@ class WebpackTokenParser implements \Twig_TokenParserInterface
             $files[] = $file;
         }
 
-        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         $body = $this->parser->subparse(function ($token) {
             return $token->test(['end' . $this->getTag()]);
         }, true);
 
-        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         return new WebpackNode([$body], ['files' => $files], $lineno, $this->getTag());
     }
 
     /**
-     * @param \Twig_TokenStream $stream
-     * @param int               $lineno
+     * @param TokenStream $stream
+     * @param int         $lineno
      * @return WebpackInlineNode
-     * @throws \Twig_Error_Syntax
      */
-    private function parseInline(\Twig_TokenStream $stream, $lineno)
+    private function parseInline(TokenStream $stream, $lineno)
     {
-        if ($stream->test(\Twig_Token::NAME_TYPE)) {
+        if ($stream->test(Token::NAME_TYPE)) {
             $stream->next();
         }
 
-        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
-        $this->parser->subparse(function ($token) {
+        $this->parser->subparse(function (Token $token) {
             return $token->test(['end' . $this->getTag()]);
         }, true);
 
-        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
-        $file = $this->parser->getEnvironment()->getLoader()->getCacheKey($stream->getFilename());
-
+        $file = $this->loader->getCacheKey($stream->getSourceContext()->getName());
         if (! isset($this->inline_blocks[$file])) {
             $this->inline_blocks[$file] = 0;
         }

--- a/src/Bundle/Twig/Token/WebpackTokenParser.php
+++ b/src/Bundle/Twig/Token/WebpackTokenParser.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Twig\Token;
 

--- a/src/Bundle/Twig/TwigExtension.php
+++ b/src/Bundle/Twig/TwigExtension.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Twig;
 

--- a/src/Bundle/Twig/TwigExtension.php
+++ b/src/Bundle/Twig/TwigExtension.php
@@ -1,15 +1,24 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Twig;
 
 use Hostnet\Bundle\WebpackBundle\DependencyInjection\Configuration;
 use Hostnet\Bundle\WebpackBundle\Twig\Token\WebpackTokenParser;
 use Hostnet\Component\Webpack\Asset\Compiler;
+use Twig\Extension\AbstractExtension;
+use Twig\Loader\LoaderInterface;
+use Twig\TwigFunction;
 
 /**
  * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class TwigExtension extends \Twig_Extension
+class TwigExtension extends AbstractExtension
 {
+    /**
+     * @var LoaderInterface
+     */
+    private $loader;
+
     /**
      * @var string
      */
@@ -36,14 +45,16 @@ class TwigExtension extends \Twig_Extension
     private $common_css;
 
     /**
-     * @param string $web_dir
-     * @param string $public_path
-     * @param string $dump_path
-     * @param string $common_js
-     * @param string $common_css
+     * @param LoaderInterface $loader
+     * @param string          $web_dir
+     * @param string          $public_path
+     * @param string          $dump_path
+     * @param string          $common_js
+     * @param string          $common_css
      */
-    public function __construct($web_dir, $public_path, $dump_path, $common_js, $common_css)
+    public function __construct(LoaderInterface $loader, $web_dir, $public_path, $dump_path, $common_js, $common_css)
     {
+        $this->loader      = $loader;
         $this->web_dir     = $web_dir;
         $this->public_path = $public_path;
         $this->dump_path   = $dump_path;
@@ -60,17 +71,17 @@ class TwigExtension extends \Twig_Extension
     /** {@inheritdoc} */
     public function getTokenParsers()
     {
-        return [new WebpackTokenParser($this)];
+        return [new WebpackTokenParser($this, $this->loader)];
     }
 
     /** {@inheritdoc} */
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('webpack_asset', [$this, 'webpackAsset']),
-            new \Twig_SimpleFunction('webpack_public', [$this, 'webpackPublic']),
-            new \Twig_SimpleFunction('webpack_common_js', [$this, 'webpackCommonJs']),
-            new \Twig_SimpleFunction('webpack_common_css', [$this, 'webpackCommonCss']),
+            new TwigFunction('webpack_asset', [$this, 'webpackAsset']),
+            new TwigFunction('webpack_public', [$this, 'webpackPublic']),
+            new TwigFunction('webpack_common_js', [$this, 'webpackCommonJs']),
+            new TwigFunction('webpack_common_css', [$this, 'webpackCommonCss']),
         ];
     }
 

--- a/src/Bundle/WebpackBundle.php
+++ b/src/Bundle/WebpackBundle.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle;
 

--- a/src/Bundle/WebpackBundle.php
+++ b/src/Bundle/WebpackBundle.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle;
 
 use Hostnet\Bundle\WebpackBundle\DependencyInjection\WebpackCompilerPass;

--- a/src/Component/Asset/CacheGuard.php
+++ b/src/Component/Asset/CacheGuard.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
 use Psr\Log\LoggerInterface;

--- a/src/Component/Asset/CacheGuard.php
+++ b/src/Component/Asset/CacheGuard.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 

--- a/src/Component/Asset/Compiler.php
+++ b/src/Component/Asset/Compiler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
@@ -158,6 +159,10 @@ class Compiler
      */
     public static function getAliasId($path)
     {
-        return str_replace(['/', '\\'], '.', Container::underscore(ltrim(substr($path, 0, strrpos($path, '.')), '@')));
+        return str_replace(
+            ['/', '\\'],
+            '.',
+            Container::underscore(ltrim(substr($path, 0, (int) strrpos($path, '.')), '@'))
+        );
     }
 }

--- a/src/Component/Asset/Compiler.php
+++ b/src/Component/Asset/Compiler.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 

--- a/src/Component/Asset/Dumper.php
+++ b/src/Component/Asset/Dumper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
 use Psr\Log\LoggerInterface;

--- a/src/Component/Asset/Dumper.php
+++ b/src/Component/Asset/Dumper.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
@@ -26,8 +29,13 @@ class Dumper
      * @param string          $public_res_path
      * @param string          $output_dir
      */
-    public function __construct(Filesystem $fs, LoggerInterface $logger, array $bundle_paths, $public_res_path, $output_dir)
-    {
+    public function __construct(
+        Filesystem      $fs,
+        LoggerInterface $logger,
+        array           $bundle_paths,
+        string          $public_res_path,
+        string          $output_dir
+    ) {
         $this->fs              = $fs;
         $this->logger          = $logger;
         $this->bundle_paths    = $bundle_paths;

--- a/src/Component/Asset/TrackedFiles.php
+++ b/src/Component/Asset/TrackedFiles.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
 use Symfony\Component\Finder\Finder;

--- a/src/Component/Asset/TrackedFiles.php
+++ b/src/Component/Asset/TrackedFiles.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 

--- a/src/Component/Asset/Tracker.php
+++ b/src/Component/Asset/Tracker.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
 use Hostnet\Component\Webpack\Profiler\Profiler;

--- a/src/Component/Asset/Tracker.php
+++ b/src/Component/Asset/Tracker.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 

--- a/src/Component/Asset/TwigParser.php
+++ b/src/Component/Asset/TwigParser.php
@@ -1,8 +1,13 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
 use Hostnet\Bundle\WebpackBundle\Twig\Token\WebpackTokenParser;
 use Hostnet\Bundle\WebpackBundle\Twig\TwigExtension;
+use Twig\Environment;
+use Twig\Source;
+use Twig\Token;
+use Twig\TokenStream;
 
 /**
  * Parses twig templates to find split points.
@@ -18,7 +23,7 @@ class TwigParser
     /**
      * @param Tracker $tracker
      */
-    public function __construct(Tracker $tracker, \Twig_Environment $twig, $cache_dir)
+    public function __construct(Tracker $tracker, Environment $twig, $cache_dir)
     {
         $this->tracker   = $tracker;
         $this->twig      = $twig;
@@ -51,20 +56,20 @@ class TwigParser
     public function findSplitPoints($template_file)
     {
         $inline_blocks = 0;
-        $source        = new \Twig_Source(file_get_contents($template_file), $template_file);
+        $source        = new Source(file_get_contents($template_file), $template_file);
         $stream        = $this->twig->tokenize($source);
         $points        = [];
 
         while (! $stream->isEOF() && $token = $stream->next()) {
             // {{ webpack_asset(...) }}
-            if ($token->test(\Twig_Token::NAME_TYPE, 'webpack_asset')) {
+            if ($token->test(Token::NAME_TYPE, 'webpack_asset')) {
                 // We found the webpack function!
                 $asset          = $this->getAssetFromStream($template_file, $stream);
                 $points[$asset] = $this->resolveAssetPath($asset, $template_file, $token);
             }
 
             // {% webpack_javascripts %} and {% webpack_stylesheets %}
-            if ($token->test(\Twig_Token::BLOCK_START_TYPE) && $stream->getCurrent()->test(WebpackTokenParser::TAG_NAME)) {
+            if ($token->test(Token::BLOCK_START_TYPE) && $stream->getCurrent()->test(WebpackTokenParser::TAG_NAME)) {
                 $stream->next();
 
                 if ($stream->getCurrent()->getValue() === 'inline') {
@@ -75,7 +80,7 @@ class TwigParser
 
                     // Are we dealing with a custom extension? If not, fallback to javascript.
                     $extension = 'js'; // Default
-                    if ($token->test(\Twig_Token::NAME_TYPE)) {
+                    if ($token->test(Token::NAME_TYPE)) {
                         $extension = $token->getValue();
                         $stream->next();
                     }
@@ -91,8 +96,8 @@ class TwigParser
                     $inline_blocks++;
                 } else {
                     $stream->next();
-                    while (! $stream->isEOF() && ! $stream->getCurrent()->test(\Twig_Token::BLOCK_END_TYPE)) {
-                        $asset          = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
+                    while (! $stream->isEOF() && ! $stream->getCurrent()->test(Token::BLOCK_END_TYPE)) {
+                        $asset          = $stream->expect(Token::STRING_TYPE)->getValue();
                         $points[$asset] = $this->resolveAssetPath($asset, $template_file, $token);
                     }
                 }
@@ -105,7 +110,7 @@ class TwigParser
     /**
      * @param string      $asset
      * @param string      $template_file
-     * @param \Twig_Token $token
+     * @param Token $token
      */
     private function resolveAssetPath($asset, $template_file, $token)
     {
@@ -122,30 +127,30 @@ class TwigParser
     }
 
     /**
-     * @throws \Twig_Error_Syntax
      * @param  $filename
-     * @param  \Twig_TokenStream $stream
+     * @param  TokenStream $stream
+     * @return mixed
      */
-    private function getAssetFromStream($filename, \Twig_TokenStream $stream)
+    private function getAssetFromStream($filename, TokenStream $stream)
     {
-        $this->expect($filename, $stream->next(), \Twig_Token::PUNCTUATION_TYPE, '(');
+        $this->expect($filename, $stream->next(), Token::PUNCTUATION_TYPE, '(');
         $token = $stream->next();
-        $this->expect($filename, $token, \Twig_Token::STRING_TYPE);
-        $this->expect($filename, $stream->next(), \Twig_Token::PUNCTUATION_TYPE, ')');
+        $this->expect($filename, $token, Token::STRING_TYPE);
+        $this->expect($filename, $stream->next(), Token::PUNCTUATION_TYPE, ')');
 
         return $token->getValue();
     }
 
-    private function expect($filename, \Twig_Token $token, $type, $value = null)
+    private function expect($filename, Token $token, $type, $value = null)
     {
         if ($token->getType() !== $type) {
             throw new \RuntimeException(sprintf(
                 'Parse error in %s at line %d. Expected %s%s, got %s.',
                 $filename,
                 $token->getLine(),
-                \Twig_Token::typeToEnglish($type),
+                Token::typeToEnglish($type),
                 $value !== null ? ' "' . $value . '"' : '',
-                \Twig_Token::typeToEnglish($token->getType())
+                Token::typeToEnglish($token->getType())
             ));
         }
     }

--- a/src/Component/Asset/TwigParser.php
+++ b/src/Component/Asset/TwigParser.php
@@ -108,9 +108,10 @@ class TwigParser
     }
 
     /**
-     * @param string      $asset
-     * @param string      $template_file
-     * @param Token $token
+     * @param  string $asset
+     * @param  string $template_file
+     * @param  Token  $token
+     * @return string
      */
     private function resolveAssetPath($asset, $template_file, $token)
     {

--- a/src/Component/Asset/TwigParser.php
+++ b/src/Component/Asset/TwigParser.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 

--- a/src/Component/Configuration/CodeBlock.php
+++ b/src/Component/Configuration/CodeBlock.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration;
 
 /**

--- a/src/Component/Configuration/CodeBlock.php
+++ b/src/Component/Configuration/CodeBlock.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration;
 
@@ -55,7 +58,16 @@ class CodeBlock
 
     // Available types to allow easy validation
     private $types = [
-        'entry', 'header', 'resolve', 'resolve_loader', 'plugin', 'pre_loader', 'loader', 'post_loader', 'output', 'root'
+        'entry',
+        'header',
+        'resolve',
+        'resolve_loader',
+        'plugin',
+        'pre_loader',
+        'loader',
+        'post_loader',
+        'output',
+        'root'
     ];
 
     // Chunks collection

--- a/src/Component/Configuration/CodeBlockProviderInterface.php
+++ b/src/Component/Configuration/CodeBlockProviderInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration;
 
 interface CodeBlockProviderInterface

--- a/src/Component/Configuration/CodeBlockProviderInterface.php
+++ b/src/Component/Configuration/CodeBlockProviderInterface.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration;
 

--- a/src/Component/Configuration/Config/ConfigInterface.php
+++ b/src/Component/Configuration/Config/ConfigInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 
 /**

--- a/src/Component/Configuration/Config/ConfigInterface.php
+++ b/src/Component/Configuration/Config/ConfigInterface.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 

--- a/src/Component/Configuration/Config/OutputConfig.php
+++ b/src/Component/Configuration/Config/OutputConfig.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/Config/OutputConfig.php
+++ b/src/Component/Configuration/Config/OutputConfig.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 
@@ -29,7 +32,10 @@ final class OutputConfig implements ConfigInterface, ConfigExtensionInterface
             ->arrayNode('output')
                 ->validate()
                     ->ifTrue(function ($c) {
-                        return !preg_match(sprintf('~(?<web_dir>.*)%s$~', rtrim($c['public_path'], '\\/')), rtrim($c['path'], '\\/'));
+                        return !preg_match(sprintf(
+                            '~(?<web_dir>.*)%s$~',
+                            rtrim($c['public_path'], '\\/')
+                        ), rtrim($c['path'], '\\/'));
                     })
                     ->thenInvalid('webpack.output.public_path must be equal to the end of the webpack.output.path.')
                 ->end()
@@ -43,7 +49,9 @@ final class OutputConfig implements ConfigInterface, ConfigExtensionInterface
                     ->scalarNode('chunk_filename')->defaultValue('[name].[hash].chunk.js')->end()
                     ->scalarNode('source_map_filename')->defaultValue('[file].sourcemap.js')->end()
                     ->scalarNode('devtool_module_filename_template')->defaultValue('webpack:///[resource-path]')->end()
-                    ->scalarNode('devtool_fallback_module_filename_template')->defaultValue('webpack:///[resourcePath]?[hash]')->end()
+                    ->scalarNode('devtool_fallback_module_filename_template')
+                        ->defaultValue('webpack:///[resourcePath]?[hash]')
+                        ->end()
                     ->booleanNode('devtool_line_to_line')->defaultFalse()->end()
                     ->scalarNode('hot_update_chunk_filename')->defaultValue('[id].[hash].hot-update.js')->end()
                     ->scalarNode('hot_update_main_filename')->defaultValue('[hash].hot-update.json')->end()

--- a/src/Component/Configuration/Config/ResolveConfig.php
+++ b/src/Component/Configuration/Config/ResolveConfig.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 

--- a/src/Component/Configuration/Config/ResolveConfig.php
+++ b/src/Component/Configuration/Config/ResolveConfig.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/Config/ResolveLoaderConfig.php
+++ b/src/Component/Configuration/Config/ResolveLoaderConfig.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 

--- a/src/Component/Configuration/Config/ResolveLoaderConfig.php
+++ b/src/Component/Configuration/Config/ResolveLoaderConfig.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/ConfigExtensionInterface.php
+++ b/src/Component/Configuration/ConfigExtensionInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration;
 
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;

--- a/src/Component/Configuration/ConfigExtensionInterface.php
+++ b/src/Component/Configuration/ConfigExtensionInterface.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration;
 

--- a/src/Component/Configuration/ConfigGenerator.php
+++ b/src/Component/Configuration/ConfigGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration;
 
 /**

--- a/src/Component/Configuration/ConfigGenerator.php
+++ b/src/Component/Configuration/ConfigGenerator.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration;
 

--- a/src/Component/Configuration/Loader/BabelLoader.php
+++ b/src/Component/Configuration/Loader/BabelLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/Loader/BabelLoader.php
+++ b/src/Component/Configuration/Loader/BabelLoader.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 

--- a/src/Component/Configuration/Loader/CSSLoader.php
+++ b/src/Component/Configuration/Loader/CSSLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/Loader/CoffeeScriptLoader.php
+++ b/src/Component/Configuration/Loader/CoffeeScriptLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/Loader/CoffeeScriptLoader.php
+++ b/src/Component/Configuration/Loader/CoffeeScriptLoader.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 

--- a/src/Component/Configuration/Loader/CssLoader.php
+++ b/src/Component/Configuration/Loader/CssLoader.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
@@ -6,7 +9,7 @@ use Hostnet\Component\Webpack\Configuration\CodeBlock;
 use Hostnet\Component\Webpack\Configuration\ConfigExtensionInterface;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
-final class CSSLoader implements LoaderInterface, ConfigExtensionInterface
+final class CssLoader implements LoaderInterface, ConfigExtensionInterface
 {
     /**
      * @var array
@@ -46,7 +49,10 @@ final class CSSLoader implements LoaderInterface, ConfigExtensionInterface
 
         if (empty($config['filename'])) {
             // If the filename is not set, apply inline style tags.
-            return [(new CodeBlock())->set(CodeBlock::LOADER, '{ test: /\.css$/, loader: \'style-loader!css-loader\' }')];
+            return [(new CodeBlock())->set(
+                CodeBlock::LOADER,
+                '{ test: /\.css$/, loader: \'style-loader!css-loader\' }'
+            )];
         }
 
         // If a filename is set, apply the ExtractTextPlugin
@@ -54,7 +60,9 @@ final class CSSLoader implements LoaderInterface, ConfigExtensionInterface
         $code_blocks = [(new CodeBlock())
             ->set(CodeBlock::HEADER, 'var ' . $fn . ' = require("extract-text-webpack-plugin");')
             ->set(CodeBlock::LOADER, '{ test: /\.css$/, loader: '.$fn.'.extract("css-loader") }')
-            ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. ($config['all_chunks'] ? 'allChunks: true' : '') . '})')
+            ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. (
+                $config['all_chunks'] ? 'allChunks: true' : ''
+            ) . '})')
         ];
 
         // If a common_filename is set, apply the CommonsChunkPlugin.

--- a/src/Component/Configuration/Loader/LessLoader.php
+++ b/src/Component/Configuration/Loader/LessLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/Loader/LessLoader.php
+++ b/src/Component/Configuration/Loader/LessLoader.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
@@ -54,7 +57,9 @@ final class LessLoader implements LoaderInterface, ConfigExtensionInterface
         $code_blocks = [(new CodeBlock())
             ->set(CodeBlock::HEADER, 'var ' . $fn . ' = require("extract-text-webpack-plugin");')
             ->set(CodeBlock::LOADER, '{ test: /\.less$/, loader: '.$fn.'.extract("css!less") }')
-            ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. ($config['all_chunks'] ? 'allChunks: true' : '') . '})')
+            ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. (
+                $config['all_chunks'] ? 'allChunks: true' : ''
+            ) . '})')
         ];
 
         // If a common_filename is set, apply the CommonsChunkPlugin.

--- a/src/Component/Configuration/Loader/LoaderInterface.php
+++ b/src/Component/Configuration/Loader/LoaderInterface.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 

--- a/src/Component/Configuration/Loader/LoaderInterface.php
+++ b/src/Component/Configuration/Loader/LoaderInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 /**

--- a/src/Component/Configuration/Loader/SassLoader.php
+++ b/src/Component/Configuration/Loader/SassLoader.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
@@ -50,7 +53,10 @@ final class SassLoader implements LoaderInterface, ConfigExtensionInterface
         }
 
         if (!empty($config['include_paths'])) {
-            $block->set(CodeBlock::ROOT, 'sassLoader: { includePaths: [\'' . implode('\',\'', $config['include_paths']) . '\']}');
+            $block->set(
+                CodeBlock::ROOT,
+                'sassLoader: { includePaths: [\'' . implode('\',\'', $config['include_paths']) . '\']}'
+            );
         }
 
         if (empty($config['filename'])) {
@@ -64,11 +70,16 @@ final class SassLoader implements LoaderInterface, ConfigExtensionInterface
         $code_blocks = [(new CodeBlock())
             ->set(CodeBlock::HEADER, 'var ' . $fn . ' = require("extract-text-webpack-plugin");')
             ->set(CodeBlock::LOADER, '{ test: /\.scss$/, loader: '.$fn.'.extract("css!sass") }')
-            ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. ($config['all_chunks'] ? 'allChunks: true' : '') . '})')
+            ->set(CodeBlock::PLUGIN, 'new ' . $fn . '("' . $config['filename'] . '", {'. (
+                $config['all_chunks'] ? 'allChunks: true' : ''
+            ) . '})')
         ];
 
         if (!empty($config['include_paths'])) {
-            $code_blocks[0]->set(CodeBlock::ROOT, 'sassLoader: { includePaths: [\'' . implode('\',\'', $config['include_paths']) . '\']}');
+            $code_blocks[0]->set(
+                CodeBlock::ROOT,
+                'sassLoader: { includePaths: [\'' . implode('\',\'', $config['include_paths']) . '\']}'
+            );
         }
 
         // If a common_filename is set, apply the CommonsChunkPlugin.

--- a/src/Component/Configuration/Loader/SassLoader.php
+++ b/src/Component/Configuration/Loader/SassLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/Loader/TypeScriptLoader.php
+++ b/src/Component/Configuration/Loader/TypeScriptLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/Loader/TypeScriptLoader.php
+++ b/src/Component/Configuration/Loader/TypeScriptLoader.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 

--- a/src/Component/Configuration/Loader/UrlLoader.php
+++ b/src/Component/Configuration/Loader/UrlLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/Loader/UrlLoader.php
+++ b/src/Component/Configuration/Loader/UrlLoader.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 

--- a/src/Component/Configuration/Plugin/DefinePlugin.php
+++ b/src/Component/Configuration/Plugin/DefinePlugin.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Plugin;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/Plugin/DefinePlugin.php
+++ b/src/Component/Configuration/Plugin/DefinePlugin.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Plugin;
 

--- a/src/Component/Configuration/Plugin/PluginInterface.php
+++ b/src/Component/Configuration/Plugin/PluginInterface.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Plugin;
 

--- a/src/Component/Configuration/Plugin/PluginInterface.php
+++ b/src/Component/Configuration/Plugin/PluginInterface.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Plugin;
 
 /**

--- a/src/Component/Configuration/Plugin/ProvidePlugin.php
+++ b/src/Component/Configuration/Plugin/ProvidePlugin.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Plugin;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/Plugin/ProvidePlugin.php
+++ b/src/Component/Configuration/Plugin/ProvidePlugin.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Plugin;
 
@@ -31,7 +34,7 @@ final class ProvidePlugin implements PluginInterface, ConfigExtensionInterface
      */
     public function __construct(array $config = [])
     {
-        $this->config    = $config;
+        $this->config   = $config;
         $this->provides = $config['plugins']['provides'];
     }
 

--- a/src/Component/Configuration/Plugin/UglifyJsPlugin.php
+++ b/src/Component/Configuration/Plugin/UglifyJsPlugin.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Plugin;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/src/Component/Configuration/Plugin/UglifyJsPlugin.php
+++ b/src/Component/Configuration/Plugin/UglifyJsPlugin.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Plugin;
 
@@ -87,7 +90,11 @@ final class UglifyJsPlugin implements PluginInterface, ConfigExtensionInterface
         $uglify
             ->booleanNode('source_map')
                 ->defaultTrue()
-                ->info('The plugin uses SourceMaps to map error message locations to modules. This slows down the compilation')
+                ->info(sprintf(
+                    '%s %s',
+                    'The plugin uses SourceMaps to map error message locations to modules.',
+                    'This slows down the compilation'
+                ))
             ->end();
 
         $uglify

--- a/src/Component/Profiler/Profiler.php
+++ b/src/Component/Profiler/Profiler.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Profiler;
 

--- a/src/Component/Profiler/Profiler.php
+++ b/src/Component/Profiler/Profiler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Profiler;
 
 /**

--- a/src/Component/Profiler/WebpackDataCollector.php
+++ b/src/Component/Profiler/WebpackDataCollector.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Profiler;
 

--- a/src/Component/Profiler/WebpackDataCollector.php
+++ b/src/Component/Profiler/WebpackDataCollector.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Profiler;
 
 use Hostnet\Bundle\WebpackBundle\DependencyInjection\Configuration;

--- a/test/Bundle/CacheWarmer/WebpackCompileCacheWarmerTest.php
+++ b/test/Bundle/CacheWarmer/WebpackCompileCacheWarmerTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\CacheWarmer;
 

--- a/test/Bundle/CacheWarmer/WebpackCompileCacheWarmerTest.php
+++ b/test/Bundle/CacheWarmer/WebpackCompileCacheWarmerTest.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\CacheWarmer;
 
 use Hostnet\Component\Webpack\Asset\CacheGuard;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Hostnet\Bundle\WebpackBundle\CacheWarmer\WebpackCompileCacheWarmer
+ * @covers \Hostnet\Bundle\WebpackBundle\CacheWarmer\WebpackCompileCacheWarmer
  */
-class WebpackCompileCacheWarmerTest extends \PHPUnit_Framework_TestCase
+class WebpackCompileCacheWarmerTest extends TestCase
 {
-
     /**
      * Simple test to see the guard is executed from the cache warmer.
      */

--- a/test/Bundle/Command/CompileCommandTest.php
+++ b/test/Bundle/Command/CompileCommandTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Command;
 

--- a/test/Bundle/Command/CompileCommandTest.php
+++ b/test/Bundle/Command/CompileCommandTest.php
@@ -1,16 +1,17 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Command;
 
 use Hostnet\Component\Webpack\Asset\CacheGuard;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 
 /**
- * @covers Hostnet\Bundle\WebpackBundle\Command\CompileCommand
+ * @covers \Hostnet\Bundle\WebpackBundle\Command\CompileCommand
  */
-class CompileCommandTest extends \PHPUnit_Framework_TestCase
+class CompileCommandTest extends TestCase
 {
-
     /**
      * Simple test to see the validate function is executed from the CacheGard class.
      */

--- a/test/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/test/Bundle/DependencyInjection/ConfigurationTest.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 
 use Hostnet\Component\Webpack\Configuration\Loader\CSSLoader;
 use Hostnet\Component\Webpack\Configuration\Plugin\DefinePlugin;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Hostnet\Bundle\WebpackBundle\DependencyInjection\Configuration
- * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     public function testGetConfigTreeBuilder()
     {
@@ -16,15 +17,15 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $tree   = $config->getConfigTreeBuilder();
         $final  = $tree->buildTree()->finalize([]);
 
-        $this->assertArrayHasKey('node', $final);
-        $this->assertArrayHasKey('compile_timeout', $final);
+        self::assertArrayHasKey('node', $final);
+        self::assertArrayHasKey('compile_timeout', $final);
 
-        $this->assertArrayHasKey('binary', $final['node']);
-        $this->assertArrayHasKey('win32', $final['node']['binary']);
-        $this->assertArrayHasKey('win64', $final['node']['binary']);
-        $this->assertArrayHasKey('linux_x32', $final['node']['binary']);
-        $this->assertArrayHasKey('linux_x64', $final['node']['binary']);
-        $this->assertArrayHasKey('darwin', $final['node']['binary']);
-        $this->assertArrayHasKey('fallback', $final['node']['binary']);
+        self::assertArrayHasKey('binary', $final['node']);
+        self::assertArrayHasKey('win32', $final['node']['binary']);
+        self::assertArrayHasKey('win64', $final['node']['binary']);
+        self::assertArrayHasKey('linux_x32', $final['node']['binary']);
+        self::assertArrayHasKey('linux_x64', $final['node']['binary']);
+        self::assertArrayHasKey('darwin', $final['node']['binary']);
+        self::assertArrayHasKey('fallback', $final['node']['binary']);
     }
 }

--- a/test/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/test/Bundle/DependencyInjection/ConfigurationTest.php
@@ -1,8 +1,11 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 
-use Hostnet\Component\Webpack\Configuration\Loader\CSSLoader;
+use Hostnet\Component\Webpack\Configuration\Loader\CssLoader;
 use Hostnet\Component\Webpack\Configuration\Plugin\DefinePlugin;
 use PHPUnit\Framework\TestCase;
 
@@ -13,7 +16,7 @@ class ConfigurationTest extends TestCase
 {
     public function testGetConfigTreeBuilder()
     {
-        $config = new Configuration([], [DefinePlugin::class, CSSLoader::class]);
+        $config = new Configuration([], [DefinePlugin::class, CssLoader::class]);
         $tree   = $config->getConfigTreeBuilder();
         $final  = $tree->buildTree()->finalize([]);
 

--- a/test/Bundle/DependencyInjection/WebpackCompilerPassTest.php
+++ b/test/Bundle/DependencyInjection/WebpackCompilerPassTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 
@@ -32,8 +35,15 @@ class WebpackCompilerPassTest extends TestCase
         $container->setParameter('kernel.cache_dir', realpath($fixture_dir . '/cache'));
         $container->set('filesystem', new Filesystem());
         $container->set('templating.finder', $this->getMockBuilder(TemplateFinderInterface::class)->getMock());
-        $container->set('twig', $this->getMockBuilder(\Twig_Environment::class)->disableOriginalConstructor()->getMock());
-        $container->set('twig.loader', $this->getMockBuilder(\Twig_Loader_Filesystem::class)->disableOriginalConstructor()->getMock());
+        $container->set('twig', $this
+            ->getMockBuilder(\Twig_Environment::class)
+            ->disableOriginalConstructor()
+            ->getMock());
+        $container->set('twig.loader', $this
+            ->getMockBuilder(\Twig_Loader_Filesystem::class)
+            ->disableOriginalConstructor()
+            ->getMock());
+
         $container->set('logger', $this->getMockBuilder(LoggerInterface::class)->getMock());
 
         $container->setDefinition(
@@ -91,7 +101,10 @@ class WebpackCompilerPassTest extends TestCase
         $container->setParameter('kernel.cache_dir', realpath($fixture_dir . '/cache'));
         $container->set('filesystem', new Filesystem());
         $container->set('templating.finder', $this->getMockBuilder(TemplateFinderInterface::class)->getMock());
-        $container->set('twig', $this->getMockBuilder(\Twig_Environment::class)->disableOriginalConstructor()->getMock());
+        $container->set('twig', $this
+            ->getMockBuilder(\Twig_Environment::class)
+            ->disableOriginalConstructor()
+            ->getMock());
         $container->set('logger', $this->getMockBuilder(LoggerInterface::class)->getMock());
 
         $bundle->build($container);

--- a/test/Bundle/DependencyInjection/WebpackCompilerPassTest.php
+++ b/test/Bundle/DependencyInjection/WebpackCompilerPassTest.php
@@ -1,10 +1,12 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 
 use Hostnet\Bundle\WebpackBundle\WebpackBundle;
 use Hostnet\Component\Webpack\Configuration\CodeBlockProviderInterface;
 use Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\BarBundle;
 use Hostnet\Fixture\WebpackBundle\Bundle\FooBundle\FooBundle;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplateFinderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -14,9 +16,8 @@ use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @covers \Hostnet\Bundle\WebpackBundle\DependencyInjection\WebpackCompilerPass
- * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class WebpackCompilerPassTest extends \PHPUnit_Framework_TestCase
+class WebpackCompilerPassTest extends TestCase
 {
     public function testPass()
     {
@@ -32,6 +33,7 @@ class WebpackCompilerPassTest extends \PHPUnit_Framework_TestCase
         $container->set('filesystem', new Filesystem());
         $container->set('templating.finder', $this->getMockBuilder(TemplateFinderInterface::class)->getMock());
         $container->set('twig', $this->getMockBuilder(\Twig_Environment::class)->disableOriginalConstructor()->getMock());
+        $container->set('twig.loader', $this->getMockBuilder(\Twig_Loader_Filesystem::class)->disableOriginalConstructor()->getMock());
         $container->set('logger', $this->getMockBuilder(LoggerInterface::class)->getMock());
 
         $container->setDefinition(
@@ -53,16 +55,16 @@ class WebpackCompilerPassTest extends \PHPUnit_Framework_TestCase
         ], $container);
         $container->compile();
 
-        $this->assertTrue($container->hasDefinition('hostnet_webpack.bridge.asset_compiler'));
-        $this->assertTrue($container->hasDefinition('hostnet_webpack.bridge.asset_tracker'));
-        $this->assertTrue($container->hasDefinition('hostnet_webpack.bridge.config_generator'));
-        $this->assertTrue($container->hasDefinition('hostnet_webpack.bridge.profiler'));
+        self::assertTrue($container->hasDefinition('hostnet_webpack.bridge.asset_compiler'));
+        self::assertTrue($container->hasDefinition('hostnet_webpack.bridge.asset_tracker'));
+        self::assertTrue($container->hasDefinition('hostnet_webpack.bridge.config_generator'));
+        self::assertTrue($container->hasDefinition('hostnet_webpack.bridge.profiler'));
 
         $method_calls = $container->getDefinition('hostnet_webpack.bridge.config_generator')->getMethodCalls();
-        $this->assertArraySubset([['addExtension', [new Reference('webpack_extension')]]], $method_calls);
+        self::assertArraySubset([['addExtension', [new Reference('webpack_extension')]]], $method_calls);
 
         $method_calls = $container->getDefinition('hostnet_webpack.bridge.asset_tracker')->getMethodCalls();
-        $this->assertEquals([['addPath', [__DIR__]]], $method_calls);
+        self::assertEquals([['addPath', [__DIR__]]], $method_calls);
 
         $process_definition = $container->getDefinition('hostnet_webpack.bridge.compiler_process');
         self::assertTrue($process_definition->hasMethodCall('setTimeout'));
@@ -104,9 +106,9 @@ class WebpackCompilerPassTest extends \PHPUnit_Framework_TestCase
         ], $container);
         $container->compile();
 
-        $this->assertTrue($container->hasDefinition('hostnet_webpack.bridge.asset_compiler'));
-        $this->assertTrue($container->hasDefinition('hostnet_webpack.bridge.asset_tracker'));
-        $this->assertTrue($container->hasDefinition('hostnet_webpack.bridge.config_generator'));
-        $this->assertTrue($container->hasDefinition('hostnet_webpack.bridge.profiler'));
+        self::assertTrue($container->hasDefinition('hostnet_webpack.bridge.asset_compiler'));
+        self::assertTrue($container->hasDefinition('hostnet_webpack.bridge.asset_tracker'));
+        self::assertTrue($container->hasDefinition('hostnet_webpack.bridge.config_generator'));
+        self::assertTrue($container->hasDefinition('hostnet_webpack.bridge.profiler'));
     }
 }

--- a/test/Bundle/DependencyInjection/WebpackExtensionTest.php
+++ b/test/Bundle/DependencyInjection/WebpackExtensionTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 

--- a/test/Bundle/DependencyInjection/WebpackExtensionTest.php
+++ b/test/Bundle/DependencyInjection/WebpackExtensionTest.php
@@ -1,19 +1,23 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @covers \Hostnet\Bundle\WebpackBundle\DependencyInjection\WebpackExtension
- * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class WebpackExtensionTest extends \PHPUnit_Framework_TestCase
+class WebpackExtensionTest extends TestCase
 {
     public function testAlias()
     {
-        $this->assertEquals(Configuration::CONFIG_ROOT, (new WebpackExtension())->getAlias());
+        self::assertEquals(Configuration::CONFIG_ROOT, (new WebpackExtension())->getAlias());
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testLoadNoConfig()
     {
         $container = new ContainerBuilder();

--- a/test/Bundle/EventListener/RequestListenerTest.php
+++ b/test/Bundle/EventListener/RequestListenerTest.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\EventListener;
 
 use Hostnet\Component\Webpack\Asset\CacheGuard;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 /**
  * @covers \Hostnet\Bundle\WebpackBundle\EventListener\RequestListener
- * @author Harold Iedema <harold@iedema.me>
  */
-class RequestListenerTest extends \PHPUnit_Framework_TestCase
+class RequestListenerTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|GetResponseEvent

--- a/test/Bundle/EventListener/RequestListenerTest.php
+++ b/test/Bundle/EventListener/RequestListenerTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\EventListener;
 
@@ -26,7 +29,6 @@ class RequestListenerTest extends TestCase
     {
         $this->event = $this->getMockBuilder(GetResponseEvent::class)->disableOriginalConstructor()->getMock();
         $this->guard = $this->getMockBuilder(CacheGuard::class)->disableOriginalConstructor()->getMock();
-
     }
 
     public function testRequestNoMasterRequest()

--- a/test/Bundle/Twig/Token/WebpackTokenParserTest.php
+++ b/test/Bundle/Twig/Token/WebpackTokenParserTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Twig\Token;
 
@@ -14,8 +17,16 @@ class WebpackTokenParserTest extends TestCase
     public function testParser()
     {
         $loader    = $this->prophesize(\Twig_LoaderInterface::class)->reveal();
-        $extension = new TwigExtension($loader, __DIR__, '/compiled', '/bundles', '/compiled/shared.js', '/compiled/shared.css');
-        $parser    = new WebpackTokenParser($extension, $loader);
+        $extension = new TwigExtension(
+            $loader,
+            __DIR__,
+            '/compiled',
+            '/bundles',
+            '/compiled/shared.js',
+            '/compiled/shared.css'
+        );
+
+        $parser = new WebpackTokenParser($extension, $loader);
 
         self::assertEquals(WebpackTokenParser::TAG_NAME, $parser->getTag());
     }

--- a/test/Bundle/Twig/Token/WebpackTokenParserTest.php
+++ b/test/Bundle/Twig/Token/WebpackTokenParserTest.php
@@ -1,19 +1,22 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Twig\Token;
 
 use Hostnet\Bundle\WebpackBundle\Twig\TwigExtension;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Hostnet\Bundle\WebpackBundle\Twig\Token\WebpackTokenParser
  * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class WebpackTokenParserTest extends \PHPUnit_Framework_TestCase
+class WebpackTokenParserTest extends TestCase
 {
     public function testParser()
     {
-        $extension = new TwigExtension(__DIR__, '/compiled', '/bundles', '/compiled/shared.js', '/compiled/shared.css');
-        $parser    = new WebpackTokenParser($extension);
+        $loader    = $this->prophesize(\Twig_LoaderInterface::class)->reveal();
+        $extension = new TwigExtension($loader, __DIR__, '/compiled', '/bundles', '/compiled/shared.js', '/compiled/shared.css');
+        $parser    = new WebpackTokenParser($extension, $loader);
 
-        $this->assertEquals(WebpackTokenParser::TAG_NAME, $parser->getTag());
+        self::assertEquals(WebpackTokenParser::TAG_NAME, $parser->getTag());
     }
 }

--- a/test/Bundle/Twig/TwigExtensionTest.php
+++ b/test/Bundle/Twig/TwigExtensionTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Twig;
 

--- a/test/Bundle/Twig/TwigExtensionTest.php
+++ b/test/Bundle/Twig/TwigExtensionTest.php
@@ -1,20 +1,23 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle\Twig;
+
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Hostnet\Bundle\WebpackBundle\Twig\TwigExtension
- * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class TwigExtensionTest extends \PHPUnit_Framework_TestCase
+class TwigExtensionTest extends TestCase
 {
     public function testExtension()
     {
-        $extension = new TwigExtension(__DIR__, '/', '/bundles', '/shared.js', '/shared.css');
+        $loader    = $this->prophesize(\Twig_LoaderInterface::class)->reveal();
+        $extension = new TwigExtension($loader, __DIR__, '/', '/bundles', '/shared.js', '/shared.css');
 
-        $this->assertEquals('webpack', $extension->getName());
-        $this->assertEquals(['js'  => false, 'css' => false], $extension->webpackAsset('@AppBundle/app.js'));
-        $this->assertEquals('/shared.js?0', $extension->webpackCommonJs());
-        $this->assertEquals('/shared.css?0', $extension->webpackCommonCss());
+        self::assertEquals('webpack', $extension->getName());
+        self::assertEquals(['js'  => false, 'css' => false], $extension->webpackAsset('@AppBundle/app.js'));
+        self::assertEquals('/shared.js?0', $extension->webpackCommonJs());
+        self::assertEquals('/shared.css?0', $extension->webpackCommonCss());
     }
 
     /**
@@ -22,8 +25,9 @@ class TwigExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testAssets($expected, $asset, $web_dir, $dump_path, $public_path)
     {
-        $extension = new TwigExtension($web_dir, $public_path, $dump_path, '', '');
-        $this->assertEquals($expected, $extension->webpackPublic($asset));
+        $loader    = $this->prophesize(\Twig_LoaderInterface::class)->reveal();
+        $extension = new TwigExtension($loader, $web_dir, $public_path, $dump_path, '', '');
+        self::assertEquals($expected, $extension->webpackPublic($asset));
     }
 
     public function assetProvider()

--- a/test/Bundle/WebpackBundleTest.php
+++ b/test/Bundle/WebpackBundleTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle;
 

--- a/test/Bundle/WebpackBundleTest.php
+++ b/test/Bundle/WebpackBundleTest.php
@@ -1,22 +1,35 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Bundle\WebpackBundle;
 
 use Hostnet\Bundle\WebpackBundle\DependencyInjection\WebpackCompilerPass;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @covers \Hostnet\Bundle\WebpackBundle\WebpackBundle
  * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class WebpackBundleTest extends \PHPUnit_Framework_TestCase
+class WebpackBundleTest extends TestCase
 {
     public function testBuild()
     {
         $bundle    = new WebpackBundle();
         $container = new ContainerBuilder();
-        $this->assertInstanceOf(DependencyInjection\WebpackExtension::class, $bundle->getContainerExtension());
+        self::assertInstanceOf(DependencyInjection\WebpackExtension::class, $bundle->getContainerExtension());
         $bundle->build($container);
 
-        $this->assertContainsOnlyInstancesOf(WebpackCompilerPass::class, $container->getCompilerPassConfig()->getBeforeOptimizationPasses());
+        // Since sf 3.3, there are symfony passes in the list, so we can't assert for only instances of
+        // WebpackCompilerPass anymore.
+        self::assertNotEmpty($container->getCompilerPassConfig()->getBeforeOptimizationPasses());
+
+        $found = false;
+        foreach ($container->getCompilerPassConfig()->getBeforeOptimizationPasses() as $pass) {
+            if ($pass instanceof WebpackCompilerPass) {
+                $found = true;
+            }
+        }
+
+        self::assertTrue($found);
     }
 }

--- a/test/Component/Asset/CacheGuardTest.php
+++ b/test/Component/Asset/CacheGuardTest.php
@@ -1,17 +1,18 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
 use Hostnet\Component\Webpack\Asset\Compiler;
 use Hostnet\Component\Webpack\Asset\Dumper;
 use Hostnet\Component\Webpack\Asset\Tracker;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
- * @covers Hostnet\Component\Webpack\Asset\CacheGuard
+ * @covers \Hostnet\Component\Webpack\Asset\CacheGuard
  */
-class CacheGuardTest extends \PHPUnit_Framework_TestCase
+class CacheGuardTest extends TestCase
 {
-
     /**
      * Simple test for the case the cache is outdated.
      */

--- a/test/Component/Asset/CacheGuardTest.php
+++ b/test/Component/Asset/CacheGuardTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 

--- a/test/Component/Asset/CompilerTest.php
+++ b/test/Component/Asset/CompilerTest.php
@@ -1,15 +1,16 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
 use Hostnet\Component\Webpack\Configuration\ConfigGenerator;
 use Hostnet\Component\Webpack\Profiler\Profiler;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
 /**
  * @covers \Hostnet\Component\Webpack\Asset\Compiler
- * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class CompilerTest extends \PHPUnit_Framework_TestCase
+class CompilerTest extends TestCase
 {
     private $profiler;
     private $tracker;

--- a/test/Component/Asset/CompilerTest.php
+++ b/test/Component/Asset/CompilerTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 

--- a/test/Component/Asset/DumperTest.php
+++ b/test/Component/Asset/DumperTest.php
@@ -1,6 +1,8 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -8,7 +10,7 @@ use Symfony\Component\Filesystem\Filesystem;
  * @covers \Hostnet\Component\Webpack\Asset\Dumper
  * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class DumperTest extends \PHPUnit_Framework_TestCase
+class DumperTest extends TestCase
 {
     /**
      * @var Dumper
@@ -40,6 +42,9 @@ class DumperTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testDumpDefaults()
     {
         $this->dumper->dump();

--- a/test/Component/Asset/DumperTest.php
+++ b/test/Component/Asset/DumperTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 

--- a/test/Component/Asset/TrackedFilesTest.php
+++ b/test/Component/Asset/TrackedFilesTest.php
@@ -1,15 +1,17 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * In this unit-test we simulate the 'tracked' files vs. the 'compiled' files with two directories
  * 'a' for the 'asset's to track' and 'b' the compiled version of those.
  *
- * @covers Hostnet\Component\Webpack\Asset\TrackedFiles
+ * @covers \Hostnet\Component\Webpack\Asset\TrackedFiles
  */
-class TrackedFilesTest extends \PHPUnit_Framework_TestCase
+class TrackedFilesTest extends TestCase
 {
 
     /**

--- a/test/Component/Asset/TrackedFilesTest.php
+++ b/test/Component/Asset/TrackedFilesTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
@@ -42,7 +45,6 @@ class TrackedFilesTest extends TestCase
         $this->directory_b = tempnam(sys_get_temp_dir(), 'tracked_files_unittest_b');
         unlink($this->directory_b);
         mkdir($this->directory_b);
-
     }
 
     /**
@@ -116,7 +118,6 @@ class TrackedFilesTest extends TestCase
 
         self::assertFalse($t1->modifiedAfter($t2));
         self::assertTrue($t2->modifiedAfter($t1));
-
     }
 
     /**

--- a/test/Component/Asset/TrackerTest.php
+++ b/test/Component/Asset/TrackerTest.php
@@ -1,7 +1,9 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 
 use Hostnet\Component\Webpack\Profiler\Profiler;
+use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplateFinderInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Templating\TemplateReferenceInterface;
@@ -10,7 +12,7 @@ use Symfony\Component\Templating\TemplateReferenceInterface;
  * @covers \Hostnet\Component\Webpack\Asset\Tracker
  * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class TrackerTest extends \PHPUnit_Framework_TestCase
+class TrackerTest extends TestCase
 {
     /**
      * The root directory of the application a.k.a. %kernel.root_dir%

--- a/test/Component/Asset/TrackerTest.php
+++ b/test/Component/Asset/TrackerTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 

--- a/test/Component/Asset/TwigParserTest.php
+++ b/test/Component/Asset/TwigParserTest.php
@@ -1,11 +1,14 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
+
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Hostnet\Component\Webpack\Asset\TwigParser
  * @author Harold Iedema <harold@iedema.me>
  */
-class TwigParserTest extends \PHPUnit_Framework_TestCase
+class TwigParserTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|Tracker
@@ -48,17 +51,17 @@ class TwigParserTest extends \PHPUnit_Framework_TestCase
         $file   = __DIR__ . '/Fixtures/template.html.twig';
         $points = ($parser->findSplitPoints($file));
 
-        $this->assertCount(8, $points);
-        $this->assertArrayHasKey('@BarBundle/app.js', $points);
-        $this->assertArrayHasKey('@BarBundle/app2.js', $points);
-        $this->assertArrayHasKey('@BarBundle/app3.js', $points);
-        $this->assertArrayHasKey('@BarBundle/app4.js', $points);
-        $this->assertArrayHasKey('cache/' . md5($file . 0) . '.js', $points);
-        $this->assertArrayHasKey('cache/' . md5($file . 1) . '.js', $points);
-        $this->assertArrayHasKey('cache/' . md5($file . 2) . '.less', $points);
-        $this->assertArrayHasKey('cache/' . md5($file . 3) . '.css', $points);
+        self::assertCount(8, $points);
+        self::assertArrayHasKey('@BarBundle/app.js', $points);
+        self::assertArrayHasKey('@BarBundle/app2.js', $points);
+        self::assertArrayHasKey('@BarBundle/app3.js', $points);
+        self::assertArrayHasKey('@BarBundle/app4.js', $points);
+        self::assertArrayHasKey('cache/' . md5($file . 0) . '.js', $points);
+        self::assertArrayHasKey('cache/' . md5($file . 1) . '.js', $points);
+        self::assertArrayHasKey('cache/' . md5($file . 2) . '.less', $points);
+        self::assertArrayHasKey('cache/' . md5($file . 3) . '.css', $points);
 
-        $this->assertContains('foobar', $points);
+        self::assertContains('foobar', $points);
     }
 
     /**

--- a/test/Component/Asset/TwigParserTest.php
+++ b/test/Component/Asset/TwigParserTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Asset;
 

--- a/test/Component/Configuration/CodeBlockTest.php
+++ b/test/Component/Configuration/CodeBlockTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration;
 

--- a/test/Component/Configuration/CodeBlockTest.php
+++ b/test/Component/Configuration/CodeBlockTest.php
@@ -1,5 +1,8 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration;
+
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class CodeBlockTest
@@ -7,13 +10,13 @@ namespace Hostnet\Component\Webpack\Configuration;
  * @covers \Hostnet\Component\Webpack\Configuration\CodeBlock
  * @author Harold Iedema <harold@iedema.me>
  */
-class CodeBlockTest extends \PHPUnit_Framework_TestCase
+class CodeBlockTest extends TestCase
 {
     public function testCodeBlock()
     {
         $block = (new CodeBlock())->set(CodeBlock::HEADER, 'foo');
-        $this->assertTrue($block->has(CodeBlock::HEADER));
-        $this->assertEquals('foo', $block->get(CodeBlock::HEADER));
+        self::assertTrue($block->has(CodeBlock::HEADER));
+        self::assertEquals('foo', $block->get(CodeBlock::HEADER));
     }
 
     /**

--- a/test/Component/Configuration/Config/OutputConfigTest.php
+++ b/test/Component/Configuration/Config/OutputConfigTest.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers Hostnet\Component\Webpack\Configuration\Config\OutputConfig
- * @author Harold Iedema <hiedema@hostnet.nl>
+ * @covers \Hostnet\Component\Webpack\Configuration\Config\OutputConfig
  */
-class OutputConfigTest extends \PHPUnit_Framework_TestCase
+class OutputConfigTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
@@ -20,21 +21,21 @@ class OutputConfigTest extends \PHPUnit_Framework_TestCase
 
         $config = $tree->buildTree()->finalize([]);
 
-        $this->assertArrayHasKey('output', $config);
-        $this->assertArrayHasKey('path', $config['output']);
-        $this->assertArrayHasKey('filename', $config['output']);
-        $this->assertArrayHasKey('common_id', $config['output']);
-        $this->assertArrayHasKey('chunk_filename', $config['output']);
-        $this->assertArrayHasKey('source_map_filename', $config['output']);
-        $this->assertArrayHasKey('devtool_module_filename_template', $config['output']);
-        $this->assertArrayHasKey('devtool_fallback_module_filename_template', $config['output']);
-        $this->assertArrayHasKey('devtool_line_to_line', $config['output']);
-        $this->assertArrayHasKey('hot_update_chunk_filename', $config['output']);
-        $this->assertArrayHasKey('hot_update_main_filename', $config['output']);
-        $this->assertArrayHasKey('public_path', $config['output']);
-        $this->assertArrayHasKey('jsonp_function', $config['output']);
-        $this->assertArrayHasKey('hot_update_function', $config['output']);
-        $this->assertArrayHasKey('path_info', $config['output']);
+        self::assertArrayHasKey('output', $config);
+        self::assertArrayHasKey('path', $config['output']);
+        self::assertArrayHasKey('filename', $config['output']);
+        self::assertArrayHasKey('common_id', $config['output']);
+        self::assertArrayHasKey('chunk_filename', $config['output']);
+        self::assertArrayHasKey('source_map_filename', $config['output']);
+        self::assertArrayHasKey('devtool_module_filename_template', $config['output']);
+        self::assertArrayHasKey('devtool_fallback_module_filename_template', $config['output']);
+        self::assertArrayHasKey('devtool_line_to_line', $config['output']);
+        self::assertArrayHasKey('hot_update_chunk_filename', $config['output']);
+        self::assertArrayHasKey('hot_update_main_filename', $config['output']);
+        self::assertArrayHasKey('public_path', $config['output']);
+        self::assertArrayHasKey('jsonp_function', $config['output']);
+        self::assertArrayHasKey('hot_update_function', $config['output']);
+        self::assertArrayHasKey('path_info', $config['output']);
     }
 
     public function testGetCodeBlock()
@@ -46,8 +47,8 @@ class OutputConfigTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->assertTrue($config->getCodeBlocks()[0]->has(CodeBlock::OUTPUT));
-        $this->assertArrayHasKey('filename', $config->getCodeBlocks()[0]->get(CodeBlock::OUTPUT));
-        $this->assertArrayHasKey('commonId', $config->getCodeBlocks()[0]->get(CodeBlock::OUTPUT));
+        self::assertTrue($config->getCodeBlocks()[0]->has(CodeBlock::OUTPUT));
+        self::assertArrayHasKey('filename', $config->getCodeBlocks()[0]->get(CodeBlock::OUTPUT));
+        self::assertArrayHasKey('commonId', $config->getCodeBlocks()[0]->get(CodeBlock::OUTPUT));
     }
 }

--- a/test/Component/Configuration/Config/OutputConfigTest.php
+++ b/test/Component/Configuration/Config/OutputConfigTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 

--- a/test/Component/Configuration/Config/ResolveConfigTest.php
+++ b/test/Component/Configuration/Config/ResolveConfigTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 

--- a/test/Component/Configuration/Config/ResolveConfigTest.php
+++ b/test/Component/Configuration/Config/ResolveConfigTest.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers Hostnet\Component\Webpack\Configuration\Config\ResolveConfig
- * @author Harold Iedema <hiedema@hostnet.nl>
+ * @covers \Hostnet\Component\Webpack\Configuration\Config\ResolveConfig
  */
-class ResolveConfigTest extends \PHPUnit_Framework_TestCase
+class ResolveConfigTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
@@ -20,12 +21,12 @@ class ResolveConfigTest extends \PHPUnit_Framework_TestCase
 
         $config = $tree->buildTree()->finalize([]);
 
-        $this->assertArrayHasKey('resolve', $config);
-        $this->assertArrayHasKey('root', $config['resolve']);
-        $this->assertArrayHasKey('alias', $config['resolve']);
-        $this->assertArrayHasKey('modules_directories', $config['resolve']);
-        $this->assertArrayHasKey('fallback', $config['resolve']);
-        $this->assertArrayHasKey('extensions', $config['resolve']);
+        self::assertArrayHasKey('resolve', $config);
+        self::assertArrayHasKey('root', $config['resolve']);
+        self::assertArrayHasKey('alias', $config['resolve']);
+        self::assertArrayHasKey('modules_directories', $config['resolve']);
+        self::assertArrayHasKey('fallback', $config['resolve']);
+        self::assertArrayHasKey('extensions', $config['resolve']);
     }
 
     public function testGetCodeBlock()
@@ -42,11 +43,11 @@ class ResolveConfigTest extends \PHPUnit_Framework_TestCase
         ]);
         $config->addAlias('/foo/bar', '@FooBar');
 
-        $this->assertTrue($config->getCodeBlocks()[0]->has(CodeBlock::RESOLVE));
-        $this->assertArrayHasKey('root', $config->getCodeBlocks()[0]->get(CodeBlock::RESOLVE));
-        $this->assertArrayHasKey('alias', $config->getCodeBlocks()[0]->get(CodeBlock::RESOLVE));
-        $this->assertArrayHasKey('modulesDirectories', $config->getCodeBlocks()[0]->get(CodeBlock::RESOLVE));
-        $this->assertArrayHasKey('@FooBar', $config->getCodeBlocks()[0]->get(CodeBlock::RESOLVE)['alias']);
-        $this->assertArrayHasKey('@Common', $config->getCodeBlocks()[0]->get(CodeBlock::RESOLVE)['alias']);
+        self::assertTrue($config->getCodeBlocks()[0]->has(CodeBlock::RESOLVE));
+        self::assertArrayHasKey('root', $config->getCodeBlocks()[0]->get(CodeBlock::RESOLVE));
+        self::assertArrayHasKey('alias', $config->getCodeBlocks()[0]->get(CodeBlock::RESOLVE));
+        self::assertArrayHasKey('modulesDirectories', $config->getCodeBlocks()[0]->get(CodeBlock::RESOLVE));
+        self::assertArrayHasKey('@FooBar', $config->getCodeBlocks()[0]->get(CodeBlock::RESOLVE)['alias']);
+        self::assertArrayHasKey('@Common', $config->getCodeBlocks()[0]->get(CodeBlock::RESOLVE)['alias']);
     }
 }

--- a/test/Component/Configuration/Config/ResolveLoaderConfigTest.php
+++ b/test/Component/Configuration/Config/ResolveLoaderConfigTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 

--- a/test/Component/Configuration/Config/ResolveLoaderConfigTest.php
+++ b/test/Component/Configuration/Config/ResolveLoaderConfigTest.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Config;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers Hostnet\Component\Webpack\Configuration\Config\ResolveLoaderConfig
- * @author Harold Iedema <hiedema@hostnet.nl>
+ * @covers \Hostnet\Component\Webpack\Configuration\Config\ResolveLoaderConfig
  */
-class ResolveLoaderConfigTest extends \PHPUnit_Framework_TestCase
+class ResolveLoaderConfigTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
@@ -19,7 +20,7 @@ class ResolveLoaderConfigTest extends \PHPUnit_Framework_TestCase
         $node->end();
 
         $config = $tree->buildTree()->finalize([]);
-        $this->assertArrayHasKey('resolve_loader', $config);
+        self::assertArrayHasKey('resolve_loader', $config);
     }
 
     public function testGetCodeBlock()
@@ -33,7 +34,7 @@ class ResolveLoaderConfigTest extends \PHPUnit_Framework_TestCase
             ]
         ]);
 
-        $this->assertTrue($config->getCodeBlocks()[0]->has(CodeBlock::RESOLVE_LOADER));
-        $this->assertArrayHasKey('root', $config->getCodeBlocks()[0]->get(CodeBlock::RESOLVE_LOADER));
+        self::assertTrue($config->getCodeBlocks()[0]->has(CodeBlock::RESOLVE_LOADER));
+        self::assertArrayHasKey('root', $config->getCodeBlocks()[0]->get(CodeBlock::RESOLVE_LOADER));
     }
 }

--- a/test/Component/Configuration/ConfigGeneratorTest.php
+++ b/test/Component/Configuration/ConfigGeneratorTest.php
@@ -1,11 +1,14 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration;
 
 use Hostnet\Component\Webpack\Configuration\Config\OutputConfig;
-use Hostnet\Component\Webpack\Configuration\Loader\CSSLoader;
-use Hostnet\Component\Webpack\Configuration\Plugin\DefinePlugin;
+use Hostnet\Component\Webpack\Configuration\Loader\CssLoader;
 use Hostnet\Component\Webpack\Configuration\Loader\SassLoader;
+use Hostnet\Component\Webpack\Configuration\Plugin\DefinePlugin;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -44,12 +47,23 @@ class ConfigGeneratorTest extends TestCase
         );
 
         // And some plugins
-        $config->addBlock((new DefinePlugin(['plugins' => ['constants' => ['a' => 'b']]]))->add('b', 'c')->getCodeBlocks()[0]);
-        $config->addBlock((new DefinePlugin(['plugins' => ['constants' => ['c' => 'd']]]))->add('d', 'e')->getCodeBlocks()[0]);
+        $config->addBlock(
+            (new DefinePlugin(['plugins' => ['constants' => ['a' => 'b']]]))->add('b', 'c')->getCodeBlocks()[0]
+        );
+        $config->addBlock(
+            (new DefinePlugin(['plugins' => ['constants' => ['c' => 'd']]]))->add('d', 'e')->getCodeBlocks()[0]
+        );
 
         // Add extension
         $config->addExtension(new OutputConfig(['output' => ['path' => 'path/to/output']]));
-        $config->addExtension(new SassLoader(['loaders' => ['sass' => ['enabled' => true, 'include_paths' => ['path1', 'path2'], 'filename' => 'testfile', 'all_chunks' => true]]]));
+        $config->addExtension(new SassLoader([
+            'loaders' => [
+                'sass' => [
+                    'enabled' => true,
+                    'include_paths' => ['path1', 'path2'],
+                    'filename' => 'testfile',
+                    'all_chunks' => true]]
+        ]));
 
         $fixture_file = __DIR__ . '/../../Fixture/Component/Configuration/ConfigGenerator.js';
         // file_put_contents($fixture_file, $config->getConfiguration());

--- a/test/Component/Configuration/ConfigGeneratorTest.php
+++ b/test/Component/Configuration/ConfigGeneratorTest.php
@@ -1,16 +1,18 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration;
 
 use Hostnet\Component\Webpack\Configuration\Config\OutputConfig;
 use Hostnet\Component\Webpack\Configuration\Loader\CSSLoader;
 use Hostnet\Component\Webpack\Configuration\Plugin\DefinePlugin;
 use Hostnet\Component\Webpack\Configuration\Loader\SassLoader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Hostnet\Component\Webpack\Configuration\ConfigGenerator
  * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class ConfigGeneratorTest extends \PHPUnit_Framework_TestCase
+class ConfigGeneratorTest extends TestCase
 {
     public function testBuild()
     {
@@ -53,6 +55,6 @@ class ConfigGeneratorTest extends \PHPUnit_Framework_TestCase
         // file_put_contents($fixture_file, $config->getConfiguration());
         $fixture = file_get_contents($fixture_file);
 
-        $this->assertEquals(str_replace("\r\n", "\n", $fixture), str_replace("\r\n", "\n", $config->getConfiguration()));
+        self::assertEquals(str_replace("\r\n", "\n", $fixture), str_replace("\r\n", "\n", $config->getConfiguration()));
     }
 }

--- a/test/Component/Configuration/Loader/BabelLoaderTest.php
+++ b/test/Component/Configuration/Loader/BabelLoaderTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 

--- a/test/Component/Configuration/Loader/BabelLoaderTest.php
+++ b/test/Component/Configuration/Loader/BabelLoaderTest.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers Hostnet\Component\Webpack\Configuration\Loader\BabelLoader
- * @author Harold Iedema <hiedema@hostnet.nl>
+ * @covers \Hostnet\Component\Webpack\Configuration\Loader\BabelLoader
  */
-class BabelLoaderTest extends \PHPUnit_Framework_TestCase
+class BabelLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
@@ -20,8 +21,8 @@ class BabelLoaderTest extends \PHPUnit_Framework_TestCase
 
         $config = $tree->buildTree()->finalize([]);
 
-        $this->assertArrayHasKey('babel', $config);
-        $this->assertArrayHasKey('enabled', $config['babel']);
+        self::assertArrayHasKey('babel', $config);
+        self::assertArrayHasKey('enabled', $config['babel']);
     }
 
     public function testGetCodeBlockDefault()
@@ -29,7 +30,7 @@ class BabelLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new BabelLoader();
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertFalse($block->has(CodeBlock::LOADER));
+        self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
     public function testGetCodeBlockDisabled()
@@ -37,7 +38,7 @@ class BabelLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new BabelLoader(['loaders' => ['babel' => ['enabled' => false]]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertFalse($block->has(CodeBlock::LOADER));
+        self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
     public function testGetCodeBlock()
@@ -45,6 +46,6 @@ class BabelLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new BabelLoader(['loaders' => ['babel' => ['enabled' => true]]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertTrue($block->has(CodeBlock::LOADER));
+        self::assertTrue($block->has(CodeBlock::LOADER));
     }
 }

--- a/test/Component/Configuration/Loader/CSSLoaderTest.php
+++ b/test/Component/Configuration/Loader/CSSLoaderTest.php
@@ -1,14 +1,15 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers Hostnet\Component\Webpack\Configuration\Loader\CSSLoader
- * @author Harold Iedema <hiedema@hostnet.nl>
+ * @covers \Hostnet\Component\Webpack\Configuration\Loader\CSSLoader
  */
-class CSSLoaderTest extends \PHPUnit_Framework_TestCase
+class CSSLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
@@ -20,26 +21,26 @@ class CSSLoaderTest extends \PHPUnit_Framework_TestCase
 
         $config = $tree->buildTree()->finalize([]);
 
-        $this->assertArrayHasKey('css', $config);
-        $this->assertArrayHasKey('enabled', $config['css']);
-        $this->assertArrayHasKey('all_chunks', $config['css']);
-        $this->assertArrayHasKey('filename', $config['css']);
+        self::assertArrayHasKey('css', $config);
+        self::assertArrayHasKey('enabled', $config['css']);
+        self::assertArrayHasKey('all_chunks', $config['css']);
+        self::assertArrayHasKey('filename', $config['css']);
     }
 
     public function testGetCodeBlockDisabled()
     {
         $config = new CSSLoader(['loaders' => ['css' => ['enabled' => false]]]);
 
-        $this->assertFalse($config->getCodeBlocks()[0]->has(CodeBlock::LOADER));
+        self::assertFalse($config->getCodeBlocks()[0]->has(CodeBlock::LOADER));
     }
 
     public function testGetCodeBlockEnabledDefaults()
     {
         $configs = (new CSSLoader(['loaders' => ['css' => ['enabled' => true]]]))->getCodeBlocks();
 
-        $this->assertTrue($configs[0]->has(CodeBlock::LOADER));
-        $this->assertFalse($configs[0]->has(CodeBlock::HEADER));
-        $this->assertFalse($configs[0]->has(CodeBlock::PLUGIN));
+        self::assertTrue($configs[0]->has(CodeBlock::LOADER));
+        self::assertFalse($configs[0]->has(CodeBlock::HEADER));
+        self::assertFalse($configs[0]->has(CodeBlock::PLUGIN));
     }
 
     public function testGetCodeBlockEnabledCommonsChunk()
@@ -49,9 +50,9 @@ class CSSLoaderTest extends \PHPUnit_Framework_TestCase
             'loaders' => ['css' => ['enabled' => true, 'filename' => 'blaat', 'all_chunks' => true]]
         ]))->getCodeBlocks();
 
-        $this->assertTrue($configs[0]->has(CodeBlock::LOADER));
-        $this->assertTrue($configs[0]->has(CodeBlock::HEADER));
-        $this->assertTrue($configs[0]->has(CodeBlock::PLUGIN));
-        $this->assertTrue($configs[1]->has(CodeBlock::PLUGIN));
+        self::assertTrue($configs[0]->has(CodeBlock::LOADER));
+        self::assertTrue($configs[0]->has(CodeBlock::HEADER));
+        self::assertTrue($configs[0]->has(CodeBlock::PLUGIN));
+        self::assertTrue($configs[1]->has(CodeBlock::PLUGIN));
     }
 }

--- a/test/Component/Configuration/Loader/CoffeeScriptLoaderTest.php
+++ b/test/Component/Configuration/Loader/CoffeeScriptLoaderTest.php
@@ -1,13 +1,15 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers Hostnet\Component\Webpack\Configuration\Loader\CoffeeScriptLoader
+ * @covers \Hostnet\Component\Webpack\Configuration\Loader\CoffeeScriptLoader
  */
-class CoffeeScriptLoaderTest extends \PHPUnit_Framework_TestCase
+class CoffeeScriptLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
@@ -19,8 +21,8 @@ class CoffeeScriptLoaderTest extends \PHPUnit_Framework_TestCase
 
         $config = $tree->buildTree()->finalize([]);
 
-        $this->assertArrayHasKey('coffee', $config);
-        $this->assertArrayHasKey('enabled', $config['coffee']);
+        self::assertArrayHasKey('coffee', $config);
+        self::assertArrayHasKey('enabled', $config['coffee']);
     }
 
     public function testGetCodeBlockDisabled()
@@ -28,7 +30,7 @@ class CoffeeScriptLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new CoffeeScriptLoader(['loaders' => ['coffee' => ['enabled' => false, 'loader' => 'coffee']]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertFalse($block->has(CodeBlock::LOADER));
+        self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
     public function testGetCodeBlock()
@@ -36,6 +38,6 @@ class CoffeeScriptLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new CoffeeScriptLoader(['loaders' => ['coffee' => ['enabled' => true, 'loader' => 'coffee']]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertTrue($block->has(CodeBlock::LOADER));
+        self::assertTrue($block->has(CodeBlock::LOADER));
     }
 }

--- a/test/Component/Configuration/Loader/CoffeeScriptLoaderTest.php
+++ b/test/Component/Configuration/Loader/CoffeeScriptLoaderTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 

--- a/test/Component/Configuration/Loader/CssLoaderTest.php
+++ b/test/Component/Configuration/Loader/CssLoaderTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
@@ -7,16 +10,16 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers \Hostnet\Component\Webpack\Configuration\Loader\CSSLoader
+ * @covers \Hostnet\Component\Webpack\Configuration\Loader\CssLoader
  */
-class CSSLoaderTest extends TestCase
+class CssLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
         $tree = new TreeBuilder();
         $node = $tree->root('webpack')->children();
 
-        CSSLoader::applyConfiguration($node);
+        CssLoader::applyConfiguration($node);
         $node->end();
 
         $config = $tree->buildTree()->finalize([]);
@@ -29,14 +32,14 @@ class CSSLoaderTest extends TestCase
 
     public function testGetCodeBlockDisabled()
     {
-        $config = new CSSLoader(['loaders' => ['css' => ['enabled' => false]]]);
+        $config = new CssLoader(['loaders' => ['css' => ['enabled' => false]]]);
 
         self::assertFalse($config->getCodeBlocks()[0]->has(CodeBlock::LOADER));
     }
 
     public function testGetCodeBlockEnabledDefaults()
     {
-        $configs = (new CSSLoader(['loaders' => ['css' => ['enabled' => true]]]))->getCodeBlocks();
+        $configs = (new CssLoader(['loaders' => ['css' => ['enabled' => true]]]))->getCodeBlocks();
 
         self::assertTrue($configs[0]->has(CodeBlock::LOADER));
         self::assertFalse($configs[0]->has(CodeBlock::HEADER));
@@ -45,7 +48,7 @@ class CSSLoaderTest extends TestCase
 
     public function testGetCodeBlockEnabledCommonsChunk()
     {
-        $configs = (new CSSLoader([
+        $configs = (new CssLoader([
             'output'  => ['common_id' => 'foobar'],
             'loaders' => ['css' => ['enabled' => true, 'filename' => 'blaat', 'all_chunks' => true]]
         ]))->getCodeBlocks();

--- a/test/Component/Configuration/Loader/LessLoaderTest.php
+++ b/test/Component/Configuration/Loader/LessLoaderTest.php
@@ -1,14 +1,16 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers Hostnet\Component\Webpack\Configuration\Loader\LessLoader
+ * @covers \Hostnet\Component\Webpack\Configuration\Loader\LessLoader
  * @author Harold Iedema <hiedema@hostnet.nl>
  */
-class LessLoaderTest extends \PHPUnit_Framework_TestCase
+class LessLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
@@ -20,8 +22,8 @@ class LessLoaderTest extends \PHPUnit_Framework_TestCase
 
         $config = $tree->buildTree()->finalize([]);
 
-        $this->assertArrayHasKey('less', $config);
-        $this->assertArrayHasKey('enabled', $config['less']);
+        self::assertArrayHasKey('less', $config);
+        self::assertArrayHasKey('enabled', $config['less']);
     }
 
     public function testGetCodeBlockDisabled()
@@ -29,7 +31,7 @@ class LessLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new LessLoader(['loaders' => ['less' => ['enabled' => false]]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertFalse($block->has(CodeBlock::LOADER));
+        self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
     public function testGetCodeBlock()
@@ -37,6 +39,6 @@ class LessLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new LessLoader(['loaders' => ['less' => ['enabled' => true]]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertTrue($block->has(CodeBlock::LOADER));
+        self::assertTrue($block->has(CodeBlock::LOADER));
     }
 }

--- a/test/Component/Configuration/Loader/LessLoaderTest.php
+++ b/test/Component/Configuration/Loader/LessLoaderTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 

--- a/test/Component/Configuration/Loader/SassLoaderTest.php
+++ b/test/Component/Configuration/Loader/SassLoaderTest.php
@@ -1,15 +1,15 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers Hostnet\Component\Webpack\Configuration\Loader\SassLoader
- * @author Harold Iedema <hiedema@hostnet.nl>
- * @author Guillaume Cavana <guillaume.cavana@gmail.com>
+ * @covers \Hostnet\Component\Webpack\Configuration\Loader\SassLoader
  */
-class SassLoaderTest extends \PHPUnit_Framework_TestCase
+class SassLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
@@ -21,8 +21,8 @@ class SassLoaderTest extends \PHPUnit_Framework_TestCase
 
         $config = $tree->buildTree()->finalize([]);
 
-        $this->assertArrayHasKey('sass', $config);
-        $this->assertArrayHasKey('enabled', $config['sass']);
+        self::assertArrayHasKey('sass', $config);
+        self::assertArrayHasKey('enabled', $config['sass']);
     }
 
     public function testGetCodeBlockDisabled()
@@ -30,7 +30,7 @@ class SassLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new SassLoader(['loaders' => ['sass' => ['enabled' => false]]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertFalse($block->has(CodeBlock::LOADER));
+        self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
     public function testGetCodeBlock()
@@ -38,7 +38,7 @@ class SassLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new SassLoader(['loaders' => ['sass' => ['enabled' => true]]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertTrue($block->has(CodeBlock::LOADER));
+        self::assertTrue($block->has(CodeBlock::LOADER));
     }
 
     public function testGetCodeBlockWithIncludePaths()
@@ -46,7 +46,7 @@ class SassLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new SassLoader(['loaders' => ['sass' => ['enabled' => true, 'include_paths' => ['path1', 'path2'], 'filename' => 'testfile', 'all_chunks' => true]]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertTrue($block->has(CodeBlock::ROOT));
-        $this->assertTrue($block->has(CodeBlock::HEADER));
+        self::assertTrue($block->has(CodeBlock::ROOT));
+        self::assertTrue($block->has(CodeBlock::HEADER));
     }
 }

--- a/test/Component/Configuration/Loader/SassLoaderTest.php
+++ b/test/Component/Configuration/Loader/SassLoaderTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
@@ -43,7 +46,16 @@ class SassLoaderTest extends TestCase
 
     public function testGetCodeBlockWithIncludePaths()
     {
-        $config = new SassLoader(['loaders' => ['sass' => ['enabled' => true, 'include_paths' => ['path1', 'path2'], 'filename' => 'testfile', 'all_chunks' => true]]]);
+        $config = new SassLoader([
+            'loaders' => [
+                'sass' => [
+                    'enabled'       => true,
+                    'include_paths' => ['path1', 'path2'],
+                    'filename'      => 'testfile',
+                    'all_chunks'    => true
+                ]
+            ]
+        ]);
         $block  = $config->getCodeBlocks()[0];
 
         self::assertTrue($block->has(CodeBlock::ROOT));

--- a/test/Component/Configuration/Loader/TypeScriptLoaderTest.php
+++ b/test/Component/Configuration/Loader/TypeScriptLoaderTest.php
@@ -1,13 +1,15 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers Hostnet\Component\Webpack\Configuration\Loader\TypeScriptLoader
+ * @covers \Hostnet\Component\Webpack\Configuration\Loader\TypeScriptLoader
  */
-class TypeScriptLoaderTest extends \PHPUnit_Framework_TestCase
+class TypeScriptLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
@@ -19,8 +21,8 @@ class TypeScriptLoaderTest extends \PHPUnit_Framework_TestCase
 
         $config = $tree->buildTree()->finalize([]);
 
-        $this->assertArrayHasKey('typescript', $config);
-        $this->assertArrayHasKey('enabled', $config['typescript']);
+        self::assertArrayHasKey('typescript', $config);
+        self::assertArrayHasKey('enabled', $config['typescript']);
     }
 
     public function testGetCodeBlockDisabled()
@@ -28,7 +30,7 @@ class TypeScriptLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new TypeScriptLoader(['loaders' => ['typescript' => ['enabled' => false, 'loader' => 'ts']]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertFalse($block->has(CodeBlock::LOADER));
+        self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
     public function testGetCodeBlock()
@@ -36,6 +38,6 @@ class TypeScriptLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new TypeScriptLoader(['loaders' => ['typescript' => ['enabled' => true, 'loader' => 'ts']]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertTrue($block->has(CodeBlock::LOADER));
+        self::assertTrue($block->has(CodeBlock::LOADER));
     }
 }

--- a/test/Component/Configuration/Loader/TypeScriptLoaderTest.php
+++ b/test/Component/Configuration/Loader/TypeScriptLoaderTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 

--- a/test/Component/Configuration/Loader/UrlLoaderTest.php
+++ b/test/Component/Configuration/Loader/UrlLoaderTest.php
@@ -1,15 +1,15 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers Hostnet\Component\Webpack\Configuration\Loader\UrlLoader
- * @author Harold Iedema <hiedema@hostnet.nl>
- * @author Guillaume Cavana <guillaume.cavana@gmail.com>
+ * @covers \Hostnet\Component\Webpack\Configuration\Loader\UrlLoader
  */
-class UrlLoaderTest extends \PHPUnit_Framework_TestCase
+class UrlLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
@@ -20,10 +20,10 @@ class UrlLoaderTest extends \PHPUnit_Framework_TestCase
         $node->end();
 
         $config = $tree->buildTree()->finalize([]);
-        $this->assertArrayHasKey('url', $config);
-        $this->assertArrayHasKey('font_extensions', $config['url']);
-        $this->assertArrayHasKey('image_extensions', $config['url']);
-        $this->assertArrayHasKey('enabled', $config['url']);
+        self::assertArrayHasKey('url', $config);
+        self::assertArrayHasKey('font_extensions', $config['url']);
+        self::assertArrayHasKey('image_extensions', $config['url']);
+        self::assertArrayHasKey('enabled', $config['url']);
     }
 
     public function testGetCodeBlockDisabled()
@@ -31,7 +31,7 @@ class UrlLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new UrlLoader(['loaders' => ['url' => ['enabled' => false]]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertFalse($block->has(CodeBlock::LOADER));
+        self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
     public function testGetFontExtensionCodeBlock()
@@ -39,8 +39,8 @@ class UrlLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new UrlLoader(['loaders' => ['url' => ['enabled' => true, 'font_extensions' => 'svg,woff', 'limit' => 100]]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertCount(2, $config->getCodeBlocks());
-        $this->assertTrue($block->has(CodeBlock::LOADER));
+        self::assertCount(2, $config->getCodeBlocks());
+        self::assertTrue($block->has(CodeBlock::LOADER));
     }
 
     public function testGetImageExtensionCodeBlock()
@@ -48,7 +48,7 @@ class UrlLoaderTest extends \PHPUnit_Framework_TestCase
         $config = new UrlLoader(['loaders' => ['url' => ['enabled' => true, 'image_extensions' => 'png', 'limit' => 100]]]);
         $block  = $config->getCodeBlocks()[0];
 
-        $this->assertCount(1, $config->getCodeBlocks());
-        $this->assertTrue($block->has(CodeBlock::LOADER));
+        self::assertCount(1, $config->getCodeBlocks());
+        self::assertTrue($block->has(CodeBlock::LOADER));
     }
 }

--- a/test/Component/Configuration/Loader/UrlLoaderTest.php
+++ b/test/Component/Configuration/Loader/UrlLoaderTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Loader;
 
@@ -36,7 +39,9 @@ class UrlLoaderTest extends TestCase
 
     public function testGetFontExtensionCodeBlock()
     {
-        $config = new UrlLoader(['loaders' => ['url' => ['enabled' => true, 'font_extensions' => 'svg,woff', 'limit' => 100]]]);
+        $config = new UrlLoader([
+            'loaders' => ['url' => ['enabled' => true, 'font_extensions' => 'svg,woff', 'limit' => 100]]
+        ]);
         $block  = $config->getCodeBlocks()[0];
 
         self::assertCount(2, $config->getCodeBlocks());
@@ -45,7 +50,9 @@ class UrlLoaderTest extends TestCase
 
     public function testGetImageExtensionCodeBlock()
     {
-        $config = new UrlLoader(['loaders' => ['url' => ['enabled' => true, 'image_extensions' => 'png', 'limit' => 100]]]);
+        $config = new UrlLoader([
+            'loaders' => ['url' => ['enabled' => true, 'image_extensions' => 'png', 'limit' => 100]]
+        ]);
         $block  = $config->getCodeBlocks()[0];
 
         self::assertCount(1, $config->getCodeBlocks());

--- a/test/Component/Configuration/Plugin/DefinePluginTest.php
+++ b/test/Component/Configuration/Plugin/DefinePluginTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Plugin;
 

--- a/test/Component/Configuration/Plugin/DefinePluginTest.php
+++ b/test/Component/Configuration/Plugin/DefinePluginTest.php
@@ -1,15 +1,19 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Plugin;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers Hostnet\Component\Webpack\Configuration\Plugin\DefinePlugin
- * @author Harold Iedema <hiedema@hostnet.nl>
+ * @covers \Hostnet\Component\Webpack\Configuration\Plugin\DefinePlugin
  */
-class DefinePluginTest extends \PHPUnit_Framework_TestCase
+class DefinePluginTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testConfigTreeBuilder()
     {
         $tree = new TreeBuilder();
@@ -33,7 +37,7 @@ class DefinePluginTest extends \PHPUnit_Framework_TestCase
 
         $config->add('bar', 'baz');
 
-        $this->assertEquals(
+        self::assertEquals(
             'new webpack.DefinePlugin({"foo":"bar","bar":"baz"})',
             $config->getCodeBlocks()[0]->get(CodeBlock::PLUGIN)
         );

--- a/test/Component/Configuration/Plugin/ProvidePluginTest.php
+++ b/test/Component/Configuration/Plugin/ProvidePluginTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Plugin;
 

--- a/test/Component/Configuration/Plugin/ProvidePluginTest.php
+++ b/test/Component/Configuration/Plugin/ProvidePluginTest.php
@@ -1,16 +1,19 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Configuration\Plugin;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
- * @covers Hostnet\Component\Webpack\Configuration\Plugin\ProvidePlugin
- * @author Harold Iedema <hiedema@hostnet.nl>
- * @author Guillaume Cavana <guillaume.cavana@gmail.com>
+ * @covers \Hostnet\Component\Webpack\Configuration\Plugin\ProvidePlugin
  */
-class ProvidePluginTest extends \PHPUnit_Framework_TestCase
+class ProvidePluginTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testConfigTreeBuilder()
     {
         $tree = new TreeBuilder();
@@ -34,7 +37,7 @@ class ProvidePluginTest extends \PHPUnit_Framework_TestCase
 
         $config->add('jQuery', 'jquery');
 
-        $this->assertEquals(
+        self::assertEquals(
             'new webpack.ProvidePlugin({"$":"jquery","jQuery":"jquery"})',
             $config->getCodeBlocks()[0]->get(CodeBlock::PLUGIN)
         );

--- a/test/Component/Profiler/WebpackDataCollectorTest.php
+++ b/test/Component/Profiler/WebpackDataCollectorTest.php
@@ -1,15 +1,16 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Profiler;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @covers Hostnet\Component\Webpack\Profiler\Profiler
- * @covers Hostnet\Component\Webpack\Profiler\WebpackDataCollector
- * @author Harold Iedema <hiedema@hostnet.nl>
+ * @covers \Hostnet\Component\Webpack\Profiler\Profiler
+ * @covers \Hostnet\Component\Webpack\Profiler\WebpackDataCollector
  */
-class WebpackDataCollectorTest extends \PHPUnit_Framework_TestCase
+class WebpackDataCollectorTest extends TestCase
 {
     public function testProfiler()
     {
@@ -21,7 +22,7 @@ class WebpackDataCollectorTest extends \PHPUnit_Framework_TestCase
             $this->getMockBuilder(Response::class)->getMock()
         );
 
-        $this->assertEquals('hoi', $collector->get('foobar'));
-        $this->assertEquals('webpack', $collector->getName());
+        self::assertEquals('hoi', $collector->get('foobar'));
+        self::assertEquals('webpack', $collector->getName());
     }
 }

--- a/test/Component/Profiler/WebpackDataCollectorTest.php
+++ b/test/Component/Profiler/WebpackDataCollectorTest.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Component\Webpack\Profiler;
 

--- a/test/Fixture/Bundle/BarBundle/BarBundle.php
+++ b/test/Fixture/Bundle/BarBundle/BarBundle.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Fixture\WebpackBundle\Bundle\BarBundle;
 

--- a/test/Fixture/Bundle/BarBundle/BarBundle.php
+++ b/test/Fixture/Bundle/BarBundle/BarBundle.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Fixture\WebpackBundle\Bundle\BarBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/test/Fixture/Bundle/BarBundle/DependencyInjection/BarExtension.php
+++ b/test/Fixture/Bundle/BarBundle/DependencyInjection/BarExtension.php
@@ -1,11 +1,14 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration

--- a/test/Fixture/Bundle/BarBundle/DependencyInjection/BarExtension.php
+++ b/test/Fixture/Bundle/BarBundle/DependencyInjection/BarExtension.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/test/Fixture/Bundle/BarBundle/Loader/MockLoader.php
+++ b/test/Fixture/Bundle/BarBundle/Loader/MockLoader.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\Loader;
 
 use Hostnet\Component\Webpack\Configuration\CodeBlock;

--- a/test/Fixture/Bundle/BarBundle/Loader/MockLoader.php
+++ b/test/Fixture/Bundle/BarBundle/Loader/MockLoader.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\Loader;
 

--- a/test/Fixture/Bundle/FooBundle/FooBundle.php
+++ b/test/Fixture/Bundle/FooBundle/FooBundle.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 namespace Hostnet\Fixture\WebpackBundle\Bundle\FooBundle;
 

--- a/test/Fixture/Bundle/FooBundle/FooBundle.php
+++ b/test/Fixture/Bundle/FooBundle/FooBundle.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 namespace Hostnet\Fixture\WebpackBundle\Bundle\FooBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/test/Fixture/TestKernel.php
+++ b/test/Fixture/TestKernel.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel;
@@ -14,12 +17,12 @@ class TestKernel extends Kernel
     public function registerBundles()
     {
         return array(
-            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
-            new Symfony\Bundle\TwigBundle\TwigBundle(),
-            new Hostnet\Bundle\WebpackBundle\WebpackBundle(),
-            new Symfony\Bundle\MonologBundle\MonologBundle(),
-            new Hostnet\Fixture\WebpackBundle\Bundle\FooBundle\FooBundle(),
-            new Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\BarBundle(),
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Symfony\Bundle\TwigBundle\TwigBundle(),
+            new \Hostnet\Bundle\WebpackBundle\WebpackBundle(),
+            new \Symfony\Bundle\MonologBundle\MonologBundle(),
+            new \Hostnet\Fixture\WebpackBundle\Bundle\FooBundle\FooBundle(),
+            new \Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\BarBundle(),
         );
     }
     /**

--- a/test/Fixture/TestKernel.php
+++ b/test/Fixture/TestKernel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel;
 

--- a/test/Fixture/TestKernel.php
+++ b/test/Fixture/TestKernel.php
@@ -3,6 +3,8 @@
  * @copyright 2017 Hostnet B.V.
  */
 declare(strict_types = 1);
+namespace Hostnet\Fixture\WebpackBundle;
+
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel;
 

--- a/test/Functional/AssetTest.php
+++ b/test/Functional/AssetTest.php
@@ -1,5 +1,10 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
+namespace Hostnet\Functional;
+
 use Hostnet\Bundle\WebpackBundle\Twig\TwigExtension;
 use Hostnet\Component\Webpack\Asset\Tracker;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;

--- a/test/Functional/AssetTest.php
+++ b/test/Functional/AssetTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 use Hostnet\Bundle\WebpackBundle\Twig\TwigExtension;
 use Hostnet\Component\Webpack\Asset\Tracker;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -27,7 +28,7 @@ class AssetTest extends KernelTestCase
         /** @var $twig_ext TwigExtension */
         $twig_ext = static::$kernel->getContainer()->get('hostnet_webpack.bridge.twig_extension');
 
-        $this->assertEquals('/bundles/henk.png', $twig_ext->webpackPublic('henk.png'));
+        self::assertEquals('/bundles/henk.png', $twig_ext->webpackPublic('henk.png'));
     }
 
     public function testCompiledAsset()
@@ -36,7 +37,7 @@ class AssetTest extends KernelTestCase
         $container = static::$kernel->getContainer();
         $twig_ext  = $container->get('hostnet_webpack.bridge.twig_extension');
 
-        $this->assertEquals([
+        self::assertEquals([
             'js'  => false,
             'css' => false,
         ], $twig_ext->webpackAsset('henk'));
@@ -45,8 +46,8 @@ class AssetTest extends KernelTestCase
         touch($this->compiled . 'app.henk.css');
 
         $resources = $twig_ext->webpackAsset('@App/henk.js');
-        $this->assertContains('app.henk.js?', (string) $resources['js']);
-        $this->assertContains('app.henk.css?', (string) $resources['css']);
+        self::assertContains('app.henk.js?', (string) $resources['js']);
+        self::assertContains('app.henk.css?', (string) $resources['css']);
     }
 
     protected function tearDown()

--- a/test/Functional/AssetTest.php
+++ b/test/Functional/AssetTest.php
@@ -6,7 +6,7 @@ declare(strict_types = 1);
 namespace Hostnet\Functional;
 
 use Hostnet\Bundle\WebpackBundle\Twig\TwigExtension;
-use Hostnet\Component\Webpack\Asset\Tracker;
+use Hostnet\Fixture\WebpackBundle\TestKernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -15,6 +15,11 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 class AssetTest extends KernelTestCase
 {
     private $compiled;
+
+    public static function getKernelClass()
+    {
+        return TestKernel::class;
+    }
 
     protected function setUp()
     {

--- a/test/Functional/CompileTest.php
+++ b/test/Functional/CompileTest.php
@@ -1,5 +1,10 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
+namespace Hostnet\Functional;
+
 use Hostnet\Component\Webpack\Asset\Tracker;
 use Hostnet\Component\Webpack\Profiler\WebpackDataCollector;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;

--- a/test/Functional/CompileTest.php
+++ b/test/Functional/CompileTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 use Hostnet\Component\Webpack\Asset\Tracker;
 use Hostnet\Component\Webpack\Profiler\WebpackDataCollector;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -13,7 +14,7 @@ class CompileTest extends KernelTestCase
         static::bootKernel(['environment' => 'dev', 'debug' => false]);
         $collector = static::$kernel->getContainer()->get('hostnet_webpack.bridge.data_collector');
 
-        $this->assertInstanceOf(WebpackDataCollector::class, $collector);
+        self::assertInstanceOf(WebpackDataCollector::class, $collector);
     }
 
     /**
@@ -35,12 +36,12 @@ class CompileTest extends KernelTestCase
 
         $templates = array_map(array($this, 'relative'), $tracker->getTemplates());
 
-        $this->assertContains('/test/Fixture/Bundle/FooBundle/Resources/views/foo.html.twig', $templates);
-        $this->assertContains('/test/Fixture/Resources/views/template.html.twig', $templates);
+        self::assertContains('/test/Fixture/Bundle/FooBundle/Resources/views/foo.html.twig', $templates);
+        self::assertContains('/test/Fixture/Resources/views/template.html.twig', $templates);
 
         $aliases = $tracker->getAliases();
 
-        $this->assertEquals('/test/Fixture/Bundle/BarBundle/Resources/assets', $this->relative($aliases['@BarBundle']));
+        self::assertEquals('/test/Fixture/Bundle/BarBundle/Resources/assets', $this->relative($aliases['@BarBundle']));
     }
 
     private function relative($path)

--- a/test/Functional/ConfigGeneratorTest.php
+++ b/test/Functional/ConfigGeneratorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 use Hostnet\Component\Webpack\Configuration\ConfigGenerator;
 use Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\Loader\MockLoader;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -17,7 +18,7 @@ class ConfigGeneratorTest extends KernelTestCase
 
         $contiguration = $config_generator->getConfiguration();
 
-        $this->assertTrue($mock_loader->code_blocks_called);
-        $this->assertContains(MockLoader::BLOCK_CONTENT, $contiguration);
+        self::assertTrue($mock_loader->code_blocks_called);
+        self::assertContains(MockLoader::BLOCK_CONTENT, $contiguration);
     }
 }

--- a/test/Functional/ConfigGeneratorTest.php
+++ b/test/Functional/ConfigGeneratorTest.php
@@ -1,5 +1,10 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
+namespace Hostnet\Functional;
+
 use Hostnet\Component\Webpack\Configuration\ConfigGenerator;
 use Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\Loader\MockLoader;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;

--- a/test/Functional/DumperTest.php
+++ b/test/Functional/DumperTest.php
@@ -1,5 +1,10 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
+namespace Hostnet\Functional;
+
 use Hostnet\Component\Webpack\Asset\Dumper;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 

--- a/test/Functional/DumperTest.php
+++ b/test/Functional/DumperTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 use Hostnet\Component\Webpack\Asset\Dumper;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -23,7 +24,7 @@ class DumperTest extends KernelTestCase
 
         $dumper->dump();
 
-        $this->assertFileExists($this->dir . '/foo/public.js');
+        self::assertFileExists($this->dir . '/foo/public.js');
     }
 
     protected function tearDown()

--- a/test/Functional/TwigTest.php
+++ b/test/Functional/TwigTest.php
@@ -1,7 +1,11 @@
 <?php
+declare(strict_types = 1);
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\TwigBundle\TwigEngine;
 
+/**
+ * @covers \Hostnet\Bundle\WebpackBundle\Twig\Token\WebpackTokenParser
+ */
 class TwigTest extends KernelTestCase
 {
     public function testTemplates()
@@ -12,7 +16,10 @@ class TwigTest extends KernelTestCase
         $twig = static::$kernel->getContainer()->get('templating');
         $html = $twig->render('/common_id.html.twig');
 
-        $this->assertRegExp('~src="/compiled/shared\.js\?[0-9]+"~', $html);
-        $this->assertRegExp('~href="/compiled/shared\.css\?[0-9]+"~', $html);
+        self::assertRegExp('~src="/compiled/shared\.js\?[0-9]+"~', $html);
+        self::assertRegExp('~href="/compiled/shared\.css\?[0-9]+"~', $html);
+
+
+        $twig->render('/template.html.twig');
     }
 }

--- a/test/Functional/TwigTest.php
+++ b/test/Functional/TwigTest.php
@@ -19,7 +19,6 @@ class TwigTest extends KernelTestCase
         self::assertRegExp('~src="/compiled/shared\.js\?[0-9]+"~', $html);
         self::assertRegExp('~href="/compiled/shared\.css\?[0-9]+"~', $html);
 
-
         $twig->render('/template.html.twig');
     }
 }

--- a/test/Functional/TwigTest.php
+++ b/test/Functional/TwigTest.php
@@ -1,5 +1,11 @@
 <?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
 declare(strict_types = 1);
+namespace Hostnet\Functional;
+
+use Hostnet\Fixture\WebpackBundle\TestKernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\TwigBundle\TwigEngine;
 


### PR DESCRIPTION
Breaking changes include but not limited to:

- PHP 7 (strict types)
- Dropped support for Twig 1.x
- Symfony 3.3+
