### PR TITLE
Made the bundle SF(3.)4 proof

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license":     "MIT",
     "require": {
         "php":                    "^7.0",
-        "symfony/monolog-bundle": "^3.1.0",
-        "symfony/symfony":        "^3.3.0",
+        "symfony/monolog-bundle": "^4.0.0||^3.1.0",
+        "symfony/symfony":        "^4.0.0||^3.3.0",
         "twig/twig":              "^2.4.0"
     },
     "require-dev": {

--- a/src/Bundle/Resources/config/dev.yml
+++ b/src/Bundle/Resources/config/dev.yml
@@ -1,15 +1,17 @@
 services:
-
-    hostnet_webpack.bridge.request_listener:
-        class: Hostnet\Bundle\WebpackBundle\EventListener\RequestListener
+    Hostnet\Bundle\WebpackBundle\EventListener\RequestListener:
         arguments:
             - "@hostnet_webpack.bridge.asset_cacheguard"
         tags:
             - { name: "kernel.event_listener", event: "kernel.request", method: "onRequest"}
 
-    hostnet_webpack.bridge.data_collector:
-        class: Hostnet\Component\Webpack\Profiler\WebpackDataCollector
+    Hostnet\Component\Webpack\Profiler\WebpackDataCollector:
+        public: true
         arguments:
             - "@hostnet_webpack.bridge.profiler"
         tags:
             - { name: "data_collector", template: "WebpackBundle::profiler.html.twig", id: "webpack" }
+
+    # BC aliases
+    hostnet_webpack.bridge.request_listener: '@Hostnet\Bundle\WebpackBundle\EventListener\RequestListener'
+    hostnet_webpack.bridge.data_collector: '@Hostnet\Component\Webpack\Profiler\WebpackDataCollector'

--- a/src/Bundle/Resources/config/plugins.yml
+++ b/src/Bundle/Resources/config/plugins.yml
@@ -1,15 +1,12 @@
 services:
-
     hostnet_webpack.plugin.define:
         class: Hostnet\Component\Webpack\Configuration\Plugin\DefinePlugin
         tags:
             - { name: "hostnet_webpack.config_extension" }
-
     hostnet_webpack.plugin.provide:
         class: Hostnet\Component\Webpack\Configuration\Plugin\ProvidePlugin
         tags:
             - { name: "hostnet_webpack.config_extension" }
-
     hostnet_webpack.plugin.uglifyjs:
         class: Hostnet\Component\Webpack\Configuration\Plugin\UglifyJsPlugin
         tags:

--- a/src/Bundle/Resources/config/webpack.yml
+++ b/src/Bundle/Resources/config/webpack.yml
@@ -4,80 +4,72 @@ imports:
     - { resource: plugins.yml }
 
 services:
-
-    hostnet_webpack.bridge.cache_warmer:
-        class: Hostnet\Bundle\WebpackBundle\CacheWarmer\WebpackCompileCacheWarmer
+    Hostnet\Bundle\WebpackBundle\CacheWarmer\WebpackCompileCacheWarmer:
         arguments:
-            - "@hostnet_webpack.bridge.asset_cacheguard"
+            - '@Hostnet\Component\Webpack\Asset\CacheGuard'
         tags:
             - { name: "kernel.cache_warmer", priority: 10 }
 
-    hostnet_webpack.bridge.generate_config_command:
-        class: Hostnet\Bundle\WebpackBundle\Command\CompileCommand
+    Hostnet\Bundle\WebpackBundle\Command\CompileCommand:
         arguments:
-            - "@hostnet_webpack.bridge.asset_cacheguard"
+            - '@Hostnet\Component\Webpack\Asset\CacheGuard'
         tags:
             - { name: "console.command" }
 
-    hostnet_webpack.bridge.config_generator:
-        class: Hostnet\Component\Webpack\Configuration\ConfigGenerator
-
-    hostnet_webpack.bridge.asset_cacheguard:
-        class: Hostnet\Component\Webpack\Asset\CacheGuard
+    Hostnet\Component\Webpack\Asset\CacheGuard:
         arguments:
-            - "@hostnet_webpack.bridge.asset_compiler"
-            - "@hostnet_webpack.bridge.asset_dumper"
-            - "@hostnet_webpack.bridge.asset_tracker"
-            - "@logger"
+            - '@Hostnet\Component\Webpack\Asset\Compiler'
+            - '@Hostnet\Component\Webpack\Asset\Dumper'
+            - '@Hostnet\Component\Webpack\Asset\Tracker'
+            - '@logger'
 
-    hostnet_webpack.bridge.asset_tracker:
-        class: Hostnet\Component\Webpack\Asset\Tracker
+    Hostnet\Component\Webpack\Asset\Tracker:
+        public: true
         arguments:
-            - "@hostnet_webpack.bridge.profiler"
-            - "@templating.finder"
+            - '@Hostnet\Component\Webpack\Profiler\Profiler'
+            - '@templating.finder'
             - "%kernel.root_dir%"
             - "" # asset_path
             - "" # output dir
             - [] # bundles
 
-    hostnet_webpack.bridge.asset_dumper:
-        class: Hostnet\Component\Webpack\Asset\Dumper
+    Hostnet\Component\Webpack\Asset\Dumper:
+        public: true
         arguments:
-            - "@filesystem"
-            - "@logger"
+            - '@filesystem'
+            - '@logger'
             - [] # bundles
             - "" # "public" dir
             - "" # output dir
 
-    hostnet_webpack.bridge.compiler_process:
-        class: Symfony\Component\Process\Process
+    Symfony\Component\Process\Process:
+        public: true
         arguments:
             - "" # Node binary
             - "" # Cache directory
 
-    hostnet_webpack.bridge.asset_twig_parser:
-        class: Hostnet\Component\Webpack\Asset\TwigParser
+    Hostnet\Component\Webpack\Asset\TwigParser:
         arguments:
-            - "@hostnet_webpack.bridge.asset_tracker"
-            - "@twig"
+            - '@Hostnet\Component\Webpack\Asset\Tracker'
+            - '@twig'
             - "%kernel.cache_dir%"
 
-    hostnet_webpack.bridge.asset_compiler:
-        class: Hostnet\Component\Webpack\Asset\Compiler
+    Hostnet\Component\Webpack\Asset\Compiler:
+        public: true
         arguments:
-            - "@hostnet_webpack.bridge.profiler"
-            - "@hostnet_webpack.bridge.asset_tracker"
-            - "@hostnet_webpack.bridge.asset_twig_parser"
-            - "@hostnet_webpack.bridge.config_generator"
-            - "@hostnet_webpack.bridge.compiler_process"
+            - '@Hostnet\Component\Webpack\Profiler\Profiler'
+            - '@Hostnet\Component\Webpack\Asset\Tracker'
+            - '@Hostnet\Component\Webpack\Asset\TwigParser'
+            - '@Hostnet\Component\Webpack\Configuration\ConfigGenerator'
+            - '@Symfony\Component\Process\Process'
             - "%kernel.cache_dir%"
             - [] # bundles
-            - "@?debug.stopwatch"
+            - '@?debug.stopwatch'
 
-    hostnet_webpack.bridge.twig_extension:
-        class: Hostnet\Bundle\WebpackBundle\Twig\TwigExtension
+    Hostnet\Bundle\WebpackBundle\Twig\TwigExtension:
+        public: true
         arguments:
-            - "@twig.loader"
+            - '@twig.loader'
             - "" # web_path
             - "" # public_path
             - "" # dump_path
@@ -86,5 +78,20 @@ services:
         tags:
             - { name: "twig.extension" }
 
-    hostnet_webpack.bridge.profiler:
-        class: Hostnet\Component\Webpack\Profiler\Profiler
+    Hostnet\Component\Webpack\Configuration\ConfigGenerator:
+        public: true
+
+    Hostnet\Component\Webpack\Profiler\Profiler: ~
+
+    # BC aliases
+    hostnet_webpack.bridge.twig_extension: '@Hostnet\Bundle\WebpackBundle\Twig\TwigExtension'
+    hostnet_webpack.bridge.profiler: '@Hostnet\Component\Webpack\Profiler\Profiler'
+    hostnet_webpack.bridge.asset_compiler: '@Hostnet\Component\Webpack\Asset\Compiler'
+    hostnet_webpack.bridge.asset_twig_parser: '@Hostnet\Component\Webpack\Asset\TwigParser'
+    hostnet_webpack.bridge.compiler_process: '@Symfony\Component\Process\Process'
+    hostnet_webpack.bridge.asset_dumper: '@Hostnet\Component\Webpack\Asset\Dumper'
+    hostnet_webpack.bridge.cache_warmer: '@Hostnet\Bundle\WebpackBundle\CacheWarmer\WebpackCompileCacheWarmer'
+    hostnet_webpack.bridge.generate_config_command: '@Hostnet\Bundle\WebpackBundle\Command\CompileCommand'
+    hostnet_webpack.bridge.config_generator: '@Hostnet\Component\Webpack\Configuration\ConfigGenerator'
+    hostnet_webpack.bridge.asset_cacheguard: '@Hostnet\Component\Webpack\Asset\CacheGuard'
+    hostnet_webpack.bridge.asset_tracker: '@Hostnet\Component\Webpack\Asset\Tracker'

--- a/src/Component/Asset/Compiler.php
+++ b/src/Component/Asset/Compiler.php
@@ -103,6 +103,7 @@ class Compiler
         );
         $this->profiler->set('compiler.performance.prepare', $this->stopwatch->stop('webpack.prepare')->getDuration());
         $this->stopwatch->start('webpack.compiler');
+        $this->process->inheritEnvironmentVariables(true);
         $this->process->run();
 
         $output = $this->process->getOutput() . $this->process->getErrorOutput();

--- a/src/Component/Configuration/Plugin/UglifyJsPlugin.php
+++ b/src/Component/Configuration/Plugin/UglifyJsPlugin.php
@@ -61,7 +61,6 @@ final class UglifyJsPlugin implements PluginInterface, ConfigExtensionInterface
 
         $compress = $uglify
             ->arrayNode('compress')
-                ->cannotBeEmpty()
                 ->addDefaultsIfNotSet()
                 ->children();
 

--- a/src/Component/Profiler/WebpackDataCollector.php
+++ b/src/Component/Profiler/WebpackDataCollector.php
@@ -10,9 +10,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 
-/**
- * @author Iltar van der Berg <ivanderberg@hostnet.nl>
- */
 final class WebpackDataCollector implements DataCollectorInterface
 {
     /**
@@ -36,6 +33,13 @@ final class WebpackDataCollector implements DataCollectorInterface
 
     /** {@inheritdoc} */
     public function collect(Request $request, Response $response, \Exception $exception = null)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
     {
     }
 

--- a/test/Fixture/config/config.yml
+++ b/test/Fixture/config/config.yml
@@ -72,3 +72,9 @@ monolog:
             type: console
             verbosity_levels:
                 VERBOSITY_NORMAL: notice
+
+services:
+    Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\Loader\MockLoader:
+      public: true
+      tags:
+            - { name: "hostnet_webpack.config_extension" }

--- a/test/Functional/AssetTest.php
+++ b/test/Functional/AssetTest.php
@@ -9,9 +9,6 @@ use Hostnet\Bundle\WebpackBundle\Twig\TwigExtension;
 use Hostnet\Fixture\WebpackBundle\TestKernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
-/**
- * @author Iltar van der Berg <ivanderberg@hostnet.nl>
- */
 class AssetTest extends KernelTestCase
 {
     private $compiled;
@@ -36,7 +33,7 @@ class AssetTest extends KernelTestCase
         static::bootKernel();
 
         /** @var $twig_ext TwigExtension */
-        $twig_ext = static::$kernel->getContainer()->get('hostnet_webpack.bridge.twig_extension');
+        $twig_ext = static::$kernel->getContainer()->get(TwigExtension::class);
 
         self::assertEquals('/bundles/henk.png', $twig_ext->webpackPublic('henk.png'));
     }
@@ -45,7 +42,7 @@ class AssetTest extends KernelTestCase
     {
         /** @var $twig_ext TwigExtension */
         $container = static::$kernel->getContainer();
-        $twig_ext  = $container->get('hostnet_webpack.bridge.twig_extension');
+        $twig_ext  = $container->get(TwigExtension::class);
 
         self::assertEquals([
             'js'  => false,

--- a/test/Functional/CompileTest.php
+++ b/test/Functional/CompileTest.php
@@ -2,34 +2,31 @@
 /**
  * @copyright 2017 Hostnet B.V.
  */
-declare(strict_types = 1);
+declare(strict_types=1);
+
 namespace Hostnet\Functional;
 
 use Hostnet\Component\Webpack\Asset\Tracker;
 use Hostnet\Component\Webpack\Profiler\WebpackDataCollector;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
-/**
- * @author Iltar van der Berg <ivanderberg@hostnet.nl>
- */
 class CompileTest extends KernelTestCase
 {
     public function testDevCollector()
     {
         static::bootKernel(['environment' => 'dev', 'debug' => false]);
-        $collector = static::$kernel->getContainer()->get('hostnet_webpack.bridge.data_collector');
+        $collector = static::$kernel->getContainer()->get(WebpackDataCollector::class);
 
         self::assertInstanceOf(WebpackDataCollector::class, $collector);
     }
 
-    /**
-     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
-     * @expectedExceptionMessage You have requested a non-existent service "hostnet_webpack.bridge.data_collector".
-     */
     public function testMissingCollector()
     {
+        $this->expectException(ServiceNotFoundException::class);
+
         static::bootKernel(['environment' => 'test', 'debug' => false]);
-        static::$kernel->getContainer()->get('hostnet_webpack.bridge.data_collector');
+        static::$kernel->getContainer()->get(WebpackDataCollector::class);
     }
 
     public function testTrackedTemplates()
@@ -37,9 +34,9 @@ class CompileTest extends KernelTestCase
         static::bootKernel();
 
         /** @var $tracker Tracker */
-        $tracker = static::$kernel->getContainer()->get('hostnet_webpack.bridge.asset_tracker');
+        $tracker = static::$kernel->getContainer()->get(Tracker::class);
 
-        $templates = array_map(array($this, 'relative'), $tracker->getTemplates());
+        $templates = array_map([$this, 'relative'], $tracker->getTemplates());
 
         self::assertContains('/test/Fixture/Bundle/FooBundle/Resources/views/foo.html.twig', $templates);
         self::assertContains('/test/Fixture/Resources/views/template.html.twig', $templates);

--- a/test/Functional/ConfigGeneratorTest.php
+++ b/test/Functional/ConfigGeneratorTest.php
@@ -16,10 +16,10 @@ class ConfigGeneratorTest extends KernelTestCase
         static::bootKernel();
 
         /** @var $mock_loader MockLoader */
-        $mock_loader = static::$kernel->getContainer()->get('bar.mock_loader');
+        $mock_loader = static::$kernel->getContainer()->get(MockLoader::class);
 
         /** @var $config_generator ConfigGenerator */
-        $config_generator = static::$kernel->getContainer()->get('hostnet_webpack.bridge.config_generator');
+        $config_generator = static::$kernel->getContainer()->get(ConfigGenerator::class);
 
         $contiguration = $config_generator->getConfiguration();
 

--- a/test/Functional/DumperTest.php
+++ b/test/Functional/DumperTest.php
@@ -8,9 +8,6 @@ namespace Hostnet\Functional;
 use Hostnet\Component\Webpack\Asset\Dumper;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
-/**
- * @author Iltar van der Berg <ivanderberg@hostnet.nl>
- */
 class DumperTest extends KernelTestCase
 {
     protected function setUp()
@@ -25,7 +22,7 @@ class DumperTest extends KernelTestCase
         static::bootKernel();
 
         /** @var $dumper Dumper */
-        $dumper = static::$kernel->getContainer()->get('hostnet_webpack.bridge.asset_dumper');
+        $dumper = static::$kernel->getContainer()->get(Dumper::class);
 
         $dumper->dump();
 


### PR DESCRIPTION
I've update most services to use their FQCN instead of our old notation, except for `loaders.yml` and `plugins.yml` since it changes "_something_" that makes `applyConfigurationFromClass()` crash and I do not have enough knowledge of this bundle to fix it.

This PR resolves two deprecation warnings as well:
- `->cannotBeEmpty() is not applicable to concrete nodes at path "webpack.plugins.uglifyjs.compress". In 4.0 it will throw an exception.`
- `User Deprecated: Implementing "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface" without the "reset()" method is deprecated since version 3.4 and will be unsupported in 4.0 for class "Hostnet\Component\Webpack\Profiler\WebpackDataCollector".`