### PR TITLE
Require PHP7.1 from now on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,16 +10,11 @@ env:
   - COMPOSER_FLAGS="--prefer-stable"
 
 php:
-    - '7.0'
     - '7.1'
     - nightly
 
 matrix:
   include:
-    - php: 7.0
-      env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 7.0
-      env: COMPOSER_FLAGS=""
     - php: 7.1
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
     "name":        "hostnet/webpack-bundle",
     "type":        "symfony-bundle",
-    "description": "Integrates Webpack with Symfony2",
+    "description": "Integrates Webpack with Symfony",
     "license":     "MIT",
     "require": {
-        "php":                    "^7.0",
+        "php":                    "^7.1.0",
         "symfony/monolog-bundle": "^4.0.0||^3.1.0",
         "symfony/symfony":        "^4.0.0||^3.3.0",
         "twig/twig":              "^2.4.0"


### PR DESCRIPTION
As requested by @nicoschoenmaker I've updated the `composer.json`-file to require PHP7.1. After this PR we will tag the master as `2.0.0`.