### PR TITLE
Ensure our bundle works with SF 4.2

### DIFF
--- a/test/Component/Configuration/Config/OutputConfigTest.php
+++ b/test/Component/Configuration/Config/OutputConfigTest.php
@@ -17,8 +17,8 @@ class OutputConfigTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $node = $tree->root('webpack')->children();
+        $tree = new TreeBuilder('webpack');
+        $node = $tree->getRootNode()->children();
 
         OutputConfig::applyConfiguration($node);
         $node->end();

--- a/test/Component/Configuration/Config/ResolveConfigTest.php
+++ b/test/Component/Configuration/Config/ResolveConfigTest.php
@@ -17,8 +17,8 @@ class ResolveConfigTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $node = $tree->root('webpack')->children();
+        $tree = new TreeBuilder('webpack');
+        $node = $tree->getRootNode()->children();
 
         ResolveConfig::applyConfiguration($node);
         $node->end();

--- a/test/Component/Configuration/Config/ResolveLoaderConfigTest.php
+++ b/test/Component/Configuration/Config/ResolveLoaderConfigTest.php
@@ -17,8 +17,8 @@ class ResolveLoaderConfigTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $node = $tree->root('webpack')->children();
+        $tree = new TreeBuilder('webpack');
+        $node = $tree->getRootNode()->children();
 
         ResolveLoaderConfig::applyConfiguration($node);
         $node->end();

--- a/test/Component/Configuration/Loader/BabelLoaderTest.php
+++ b/test/Component/Configuration/Loader/BabelLoaderTest.php
@@ -17,8 +17,8 @@ class BabelLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $node = $tree->root('webpack')->children();
+        $tree = new TreeBuilder('webpack');
+        $node = $tree->getRootNode()->children();
 
         BabelLoader::applyConfiguration($node);
         $node->end();

--- a/test/Component/Configuration/Loader/CoffeeScriptLoaderTest.php
+++ b/test/Component/Configuration/Loader/CoffeeScriptLoaderTest.php
@@ -17,8 +17,8 @@ class CoffeeScriptLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $node = $tree->root('coffee')->children();
+        $tree = new TreeBuilder('webpack');
+        $node = $tree->getRootNode()->children();
 
         CoffeeScriptLoader::applyConfiguration($node);
         $node->end();

--- a/test/Component/Configuration/Loader/CssLoaderTest.php
+++ b/test/Component/Configuration/Loader/CssLoaderTest.php
@@ -17,8 +17,8 @@ class CssLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $node = $tree->root('webpack')->children();
+        $tree = new TreeBuilder('webpack');
+        $node = $tree->getRootNode()->children();
 
         CssLoader::applyConfiguration($node);
         $node->end();

--- a/test/Component/Configuration/Loader/LessLoaderTest.php
+++ b/test/Component/Configuration/Loader/LessLoaderTest.php
@@ -17,8 +17,8 @@ class LessLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $node = $tree->root('webpack')->children();
+        $tree = new TreeBuilder('webpack');
+        $node = $tree->getRootNode()->children();
 
         LessLoader::applyConfiguration($node);
         $node->end();

--- a/test/Component/Configuration/Loader/SassLoaderTest.php
+++ b/test/Component/Configuration/Loader/SassLoaderTest.php
@@ -17,8 +17,8 @@ class SassLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $node = $tree->root('webpack')->children();
+        $tree = new TreeBuilder('webpack');
+        $node = $tree->getRootNode()->children();
 
         SassLoader::applyConfiguration($node);
         $node->end();

--- a/test/Component/Configuration/Loader/TypeScriptLoaderTest.php
+++ b/test/Component/Configuration/Loader/TypeScriptLoaderTest.php
@@ -17,8 +17,8 @@ class TypeScriptLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $node = $tree->root('typescript')->children();
+        $tree = new TreeBuilder('webpack');
+        $node = $tree->getRootNode()->children();
 
         TypeScriptLoader::applyConfiguration($node);
         $node->end();

--- a/test/Component/Configuration/Loader/UrlLoaderTest.php
+++ b/test/Component/Configuration/Loader/UrlLoaderTest.php
@@ -17,8 +17,8 @@ class UrlLoaderTest extends TestCase
 {
     public function testConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $node = $tree->root('webpack')->children();
+        $tree = new TreeBuilder('webpack');
+        $node = $tree->getRootNode()->children();
 
         UrlLoader::applyConfiguration($node);
         $node->end();

--- a/test/Component/Configuration/Plugin/DefinePluginTest.php
+++ b/test/Component/Configuration/Plugin/DefinePluginTest.php
@@ -20,8 +20,8 @@ class DefinePluginTest extends TestCase
      */
     public function testConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $node = $tree->root('webpack')->children();
+        $tree = new TreeBuilder('webpack');
+        $node = $tree->getRootNode()->children();
 
         DefinePlugin::applyConfiguration($node);
         $node->end();

--- a/test/Component/Configuration/Plugin/ProvidePluginTest.php
+++ b/test/Component/Configuration/Plugin/ProvidePluginTest.php
@@ -20,8 +20,8 @@ class ProvidePluginTest extends TestCase
      */
     public function testConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $node = $tree->root('webpack')->children();
+        $tree = new TreeBuilder('webpack');
+        $node = $tree->getRootNode()->children();
 
         ProvidePlugin::applyConfiguration($node);
         $node->end();

--- a/test/Fixture/config/config.yml
+++ b/test/Fixture/config/config.yml
@@ -8,6 +8,9 @@ framework:
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
 
+twig:
+    strict_variables: false
+
 webpack:
     node:
         node_modules_path: "%kernel.root_dir%/node_modules"

--- a/test/Functional/DumperTest.php
+++ b/test/Functional/DumperTest.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 
 namespace Hostnet\Functional;
 
+use Hostnet\Component\Path\Path;
 use Hostnet\Component\Webpack\Asset\Dumper;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -20,7 +21,7 @@ class DumperTest extends KernelTestCase
     {
         static::bootKernel();
 
-        $this->dir = static::$kernel->getContainer()->getParameter('kernel.cache_dir') . '/../bundles';
+        $this->dir = Path::BASE_DIR . '/test/Fixture/cache/bundles';
     }
 
     public function testDump()
@@ -29,7 +30,6 @@ class DumperTest extends KernelTestCase
 
         /** @var Dumper $dumper */
         $dumper = static::$kernel->getContainer()->get(Dumper::class);
-
         $dumper->dump();
 
         self::assertFileExists($this->dir . '/foo/public.js');


### PR DESCRIPTION
I've resolved the Twig deprecation error, the TreeBuilder deprecation error and fixed a failing test.

After this PR we still need to resolve two more issues before we are fully compatible with Symfony 4.2:

> _3x: Templates directory "/webpack-bundle/test/Fixture/Resources/views" is deprecated since Symfony 4.2, use "/webpack-bundle/templates" instead._

This requires us to change how the Tracker component is wired by the `WebpackCompilerPass`.

> _3x: Passing a command as string when creating a "Symfony\Component\Process\Process" instance is deprecated since Symfony 4.2, pass it as an array of its arguments instead, or use the "Process::fromShellCommandline()" constructor if you need features provided by the shell._

This also requires us to change how the Process component is wired by the `WebpackCompilerPass`.
