### PR TITLE
use conflict rule instead of constraint on type-resolver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "php":                         "^7.1.0",
         "ext-json":                    "*",
-        "phpdocumentor/type-resolver": "^0.2.1",
         "symfony/monolog-bundle":      "^4.0.0||^3.1.0",
         "symfony/symfony":             "^4.0.0||^3.3.0",
         "twig/twig":                   "^2.4.0"
@@ -15,6 +14,9 @@
         "hostnet/phpcs-tool":     "^8.3.2",
         "phpunit/phpunit":        "^6.2.2",
         "symfony/phpunit-bridge": "^3.3.2"
+    },
+    "conflict": {
+        "phpdocumentor/type-resolver": "<0.2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Because type-resolver is a pre-release version, ^0.2.1 constricts it to be below 0.3.0, while SF 4.2 has a conflict rule with "<0.3.0"