### PR TITLE
fix: incorrect path for webpack

### DIFF
--- a/src/Bundle/DependencyInjection/WebpackCompilerPass.php
+++ b/src/Bundle/DependencyInjection/WebpackCompilerPass.php
@@ -94,7 +94,7 @@ class WebpackCompilerPass implements CompilerPassInterface
 
         $process_definition = $container
             ->getDefinition(Process::class)
-            ->replaceArgument(0, [$config['node']['binary'] . ' ' . $webpack])
+            ->replaceArgument(0, [$config['node']['binary'], $webpack])
             ->replaceArgument(1, $container->getParameter('kernel.cache_dir'))
             ->addMethodCall('setTimeout', [$config['compile_timeout']]);
 


### PR DESCRIPTION
The [Process](https://symfony.com/doc/current/components/process.html) requires the command as an array (string is deprecated since 4.2). The path and arguments must be separated in the array.