### PR TITLE
Resolved Symfony 4 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 php:
     - '7.1'
     - '7.2'
+    - '7.3'
     - nightly
 
 matrix:
@@ -23,6 +24,10 @@ matrix:
     - php: 7.2
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.2
+      env: COMPOSER_FLAGS=""
+    - php: 7.3
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 7.3
       env: COMPOSER_FLAGS=""
   allow_failures:
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require-dev": {
         "hostnet/phpcs-tool":     "^8.3.3",
-        "phpunit/phpunit":        "^8.1.6",
+        "phpunit/phpunit":        "^7.5.9",
         "symfony/phpunit-bridge": "^3.3.2"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         "twig/twig":                   "^2.7.2"
     },
     "require-dev": {
-        "hostnet/phpcs-tool":     "^8.3.2",
-        "phpunit/phpunit":        "^6.2.2",
+        "hostnet/phpcs-tool":     "^8.3.3",
+        "phpunit/phpunit":        "^8.1.6",
         "symfony/phpunit-bridge": "^3.3.2"
     },
     "conflict": {

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -62,7 +62,7 @@ class Configuration implements ConfigurationInterface
      *
      * @param NodeBuilder $node
      */
-    private function addNodeJSConfiguration(NodeBuilder $node)
+    private function addNodeJSConfiguration(NodeBuilder $node): void
     {
         $node
             ->arrayNode('node')
@@ -102,7 +102,7 @@ class Configuration implements ConfigurationInterface
      *
      * @param NodeBuilder $node
      */
-    private function addParentConfiguration(NodeBuilder $node)
+    private function addParentConfiguration(NodeBuilder $node): void
     {
         $this->applyConfigurationFromClass(ConfigInterface::class, $node);
     }
@@ -112,7 +112,7 @@ class Configuration implements ConfigurationInterface
      *
      * @param NodeBuilder $node
      */
-    private function addBundleConfiguration(NodeBuilder $node)
+    private function addBundleConfiguration(NodeBuilder $node): void
     {
         $node
             ->arrayNode('bundles')
@@ -128,7 +128,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @param NodeBuilder $node
      */
-    private function addPluginConfiguration(NodeBuilder $node)
+    private function addPluginConfiguration(NodeBuilder $node): void
     {
         $children = $node
             ->arrayNode('plugins')
@@ -144,7 +144,7 @@ class Configuration implements ConfigurationInterface
      *
      * @param NodeBuilder $node
      */
-    private function addLoaderConfiguration(NodeBuilder $node)
+    private function addLoaderConfiguration(NodeBuilder $node): void
     {
         $children = $node
             ->arrayNode('loaders')
@@ -159,7 +159,7 @@ class Configuration implements ConfigurationInterface
      * @param string      $interface
      * @param NodeBuilder $node_builder
      */
-    private function applyConfigurationFromClass($interface, NodeBuilder $node_builder)
+    private function applyConfigurationFromClass($interface, NodeBuilder $node_builder): void
     {
         foreach ($this->plugins as $name => $class_name) {
             // Only accept plugins of type PluginInterface.

--- a/src/Bundle/DependencyInjection/WebpackExtension.php
+++ b/src/Bundle/DependencyInjection/WebpackExtension.php
@@ -68,7 +68,7 @@ class WebpackExtension extends Extension
      * @codeCoverageIgnore The outcome and coverage of this method solely depends on which platform PHP is running on.
      * @return string
      */
-    private function getPlatformKey()
+    private function getPlatformKey(): string
     {
         $platform = PHP_OS;
 

--- a/src/Bundle/EventListener/RequestListener.php
+++ b/src/Bundle/EventListener/RequestListener.php
@@ -34,7 +34,7 @@ class RequestListener
      *
      * @param GetResponseEvent $event the response to send to te browser, we don't we only ensure the cache is there.
      */
-    public function onRequest(GetResponseEvent $event)
+    public function onRequest(GetResponseEvent $event): void
     {
         if (! $event->isMasterRequest()) {
             return;

--- a/src/Bundle/Resources/config/webpack.yml
+++ b/src/Bundle/Resources/config/webpack.yml
@@ -23,11 +23,16 @@ services:
             - '@Hostnet\Component\Webpack\Asset\Tracker'
             - '@logger'
 
+    Hostnet\Component\Webpack\Asset\TemplateFinder:
+        arguments:
+            - '@kernel'
+            - '%kernel.root_dir%/Resources'
+
     Hostnet\Component\Webpack\Asset\Tracker:
         public: true
         arguments:
             - '@Hostnet\Component\Webpack\Profiler\Profiler'
-            - '@templating.finder'
+            - '@Hostnet\Component\Webpack\Asset\TemplateFinder'
             - "%kernel.root_dir%"
             - "" # asset_path
             - "" # output dir

--- a/src/Bundle/Twig/Token/WebpackTokenParser.php
+++ b/src/Bundle/Twig/Token/WebpackTokenParser.php
@@ -99,7 +99,7 @@ class WebpackTokenParser implements TokenParserInterface
      * @param string      $export_type
      * @return WebpackNode
      */
-    private function parseType(TokenStream $stream, $lineno, $export_type)
+    private function parseType(TokenStream $stream, $lineno, $export_type): WebpackNode
     {
         $files = [];
         while (! $stream->isEOF() && ! $stream->getCurrent()->test(Token::BLOCK_END_TYPE)) {
@@ -127,7 +127,7 @@ class WebpackTokenParser implements TokenParserInterface
      * @param int         $lineno
      * @return WebpackInlineNode
      */
-    private function parseInline(TokenStream $stream, $lineno)
+    private function parseInline(TokenStream $stream, $lineno): WebpackInlineNode
     {
         if ($stream->test(Token::NAME_TYPE)) {
             $stream->next();

--- a/src/Bundle/Twig/TwigExtension.php
+++ b/src/Bundle/Twig/TwigExtension.php
@@ -91,7 +91,7 @@ class TwigExtension extends AbstractExtension
      * @param  string $asset
      * @return array
      */
-    public function webpackAsset($asset)
+    public function webpackAsset($asset): array
     {
         $asset_id        = $this->public_path . '/' . Compiler::getAliasId($asset);
         $full_asset_path = $this->web_dir . '/' . $asset_id;
@@ -119,7 +119,7 @@ class TwigExtension extends AbstractExtension
      * @param  string $url
      * @return string
      */
-    public function webpackPublic($url)
+    public function webpackPublic($url): string
     {
         $public_dir = '/' . ltrim($this->dump_path, '/');
 
@@ -139,7 +139,7 @@ class TwigExtension extends AbstractExtension
      *
      * @return string
      */
-    public function webpackCommonJs()
+    public function webpackCommonJs(): string
     {
         $file          = $this->web_dir . '/' . $this->common_js;
         $modified_time = file_exists($this->web_dir . '/' . $this->common_js) ? filemtime($file) : 0;
@@ -151,7 +151,7 @@ class TwigExtension extends AbstractExtension
      *
      * @return string
      */
-    public function webpackCommonCss()
+    public function webpackCommonCss(): string
     {
         $file          = $this->web_dir . '/' . $this->common_css;
         $modified_time = file_exists($this->web_dir . '/' . $this->common_css) ? filemtime($file) : 0;

--- a/src/Component/Asset/CacheGuard.php
+++ b/src/Component/Asset/CacheGuard.php
@@ -60,7 +60,7 @@ class CacheGuard
     /**
      * Rebuild the cache, check to see if it's still valid and rebuild if it's outdated.
      */
-    public function rebuild()
+    public function rebuild(): void
     {
         if ($this->tracker->isOutdated()) {
             $this->logger->info('[Webpack 1/2]: Compiling assets.');

--- a/src/Component/Asset/Compiler.php
+++ b/src/Component/Asset/Compiler.php
@@ -81,7 +81,7 @@ class Compiler
     /**
      * @return string
      */
-    public function compile()
+    public function compile(): string
     {
         $this->stopwatch->start('webpack.total');
         $this->stopwatch->start('webpack.prepare');
@@ -124,7 +124,7 @@ class Compiler
     /**
      * Adds root & alias configuration entries.
      */
-    private function addResolveConfig()
+    private function addResolveConfig(): void
     {
         $aliases = $this->tracker->getAliases();
         $this->generator->addBlock(
@@ -135,7 +135,7 @@ class Compiler
     /**
      * Add split points to the 'entry' section of the configuration.
      */
-    private function addSplitPoints()
+    private function addSplitPoints(): void
     {
         $split_points = [];
         foreach ($this->tracker->getTemplates() as $template_file) {
@@ -155,7 +155,7 @@ class Compiler
      * @param  string $path
      * @return string
      */
-    public static function getAliasId($path)
+    public static function getAliasId($path): string
     {
         return str_replace(
             ['/', '\\'],

--- a/src/Component/Asset/Dumper.php
+++ b/src/Component/Asset/Dumper.php
@@ -38,7 +38,7 @@ class Dumper
     /**
      * Iterates through resources and dump all modified resources to the bundle directory in the public dir.
      */
-    public function dump()
+    public function dump(): void
     {
         foreach ($this->bundle_paths as $name => $path) {
             if (file_exists($path . DIRECTORY_SEPARATOR . $this->public_res_path)) {
@@ -51,7 +51,7 @@ class Dumper
      * @param string $name
      * @param string $path
      */
-    private function dumpBundle($name, $path)
+    private function dumpBundle($name, $path): void
     {
         $target_dir = $this->normalize($this->getTargetDir($name));
         $path       = $this->normalize($path);
@@ -81,7 +81,7 @@ class Dumper
      * @param  string $name
      * @return string
      */
-    private function getTargetDir($name)
+    private function getTargetDir($name): string
     {
         if (substr($name, \strlen($name) - 6) === 'Bundle') {
             $name = substr($name, 0, -6);

--- a/src/Component/Asset/TemplateFinder.php
+++ b/src/Component/Asset/TemplateFinder.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @copyright 2019-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\Webpack\Asset;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Templating\TemplateReferenceInterface;
+
+class TemplateFinder
+{
+    private $kernel;
+    private $root_dir;
+    private $templates;
+
+    public function __construct(KernelInterface $kernel, string $root_dir)
+    {
+        $this->kernel   = $kernel;
+        $this->root_dir = $root_dir;
+    }
+
+    /**
+     * @return TemplateReferenceInterface[]
+     */
+    public function findAllTemplates(): array
+    {
+        if (null !== $this->templates) {
+            return $this->templates;
+        }
+
+        $templates = [];
+
+        foreach ($this->kernel->getBundles() as $bundle) {
+            $templates = array_merge($templates, $this->findTemplatesInBundle($bundle));
+        }
+
+        $templates = array_merge($templates, $this->findTemplatesInFolder($this->root_dir . '/views'));
+
+        return $this->templates = $templates;
+    }
+
+    /**
+     * @param string $directory
+     *
+     * @return TemplateReferenceInterface[]
+     */
+    private function findTemplatesInFolder(string $directory): array
+    {
+        $templates = [];
+
+        if (false === is_dir($directory)) {
+            return $templates;
+        }
+
+        /** @var SplFileInfo $file */
+        foreach ((new Finder())->files()->followLinks()->in($directory) as $file) {
+            $template = $this->parse($file->getRelativePathname());
+            if (false !== $template) {
+                $templates[] = $template;
+            }
+        }
+
+        return $templates;
+    }
+
+    /**
+     * @param BundleInterface $bundle
+     *
+     * @return TemplateReferenceInterface[]
+     */
+    private function findTemplatesInBundle(BundleInterface $bundle): array
+    {
+        $name      = $bundle->getName();
+        $templates = array_unique(array_merge(
+            $this->findTemplatesInFolder($bundle->getPath() . '/Resources/views'),
+            $this->findTemplatesInFolder($this->root_dir . '/' . $name . '/views')
+        ));
+
+        /** @var TemplateReferenceInterface $template */
+        foreach ($templates as $i => $template) {
+            $templates[$i] = $template->set('bundle', $name);
+        }
+
+        return $templates;
+    }
+
+    /**
+     * @param string $file_name
+     *
+     * @return TemplateReference|false
+     */
+    private function parse(string $file_name)
+    {
+        $parts = explode('/', str_replace('\\', '/', $file_name));
+
+        $elements = explode('.', array_pop($parts));
+        if (3 > \count($elements)) {
+            return false;
+        }
+
+        $engine = array_pop($elements);
+        $format = array_pop($elements);
+
+        return new TemplateReference('', implode('/', $parts), implode('.', $elements), $format, $engine);
+    }
+}

--- a/src/Component/Asset/TemplateReference.php
+++ b/src/Component/Asset/TemplateReference.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @copyright 2019-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\Webpack\Asset;
+
+use Symfony\Component\Templating\TemplateReference as BaseTemplateReference;
+
+class TemplateReference extends BaseTemplateReference
+{
+    public function __construct(
+        string $bundle = null,
+        string $controller = null,
+        string $name = null,
+        string $format = null,
+        string $engine = null
+    ) {
+        $this->parameters = [
+            'bundle'     => $bundle,
+            'controller' => $controller,
+            'name'       => $name,
+            'format'     => $format,
+            'engine'     => $engine,
+        ];
+    }
+
+    /**
+     * Returns the path to the template
+     *  - as a path when the template is not part of a bundle
+     *  - as a resource when the template is part of a bundle.
+     *
+     * @return string A path to the template or a resource
+     */
+    public function getPath(): string
+    {
+        $controller = str_replace('\\', '/', $this->get('controller'));
+
+        $name   = $this->get('name');
+        $format = $this->get('format');
+        $engine = $this->get('engine');
+
+        $path = (empty($controller) ? '' : $controller . '/') . $name . '.' . $format . '.' . $engine;
+
+        return empty($this->parameters['bundle'])
+            ? 'views/' . $path
+            : '@' . $this->get('bundle') . '/Resources/views/' . $path;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogicalName(): string
+    {
+        return sprintf(
+            '%s:%s:%s.%s.%s',
+            $this->parameters['bundle'],
+            $this->parameters['controller'],
+            $this->parameters['name'],
+            $this->parameters['format'],
+            $this->parameters['engine']
+        );
+    }
+}

--- a/src/Component/Asset/TrackedFiles.php
+++ b/src/Component/Asset/TrackedFiles.php
@@ -64,7 +64,7 @@ class TrackedFiles
      * @param TrackedFiles $other the other set of files to compare to.
      * @return bool true if this set if this set is modified after (later) the other set.
      */
-    public function modifiedAfter(TrackedFiles $other)
+    public function modifiedAfter(TrackedFiles $other): bool
     {
         return $this->modification_time > $other->modification_time;
     }

--- a/src/Component/Asset/TwigParser.php
+++ b/src/Component/Asset/TwigParser.php
@@ -35,7 +35,7 @@ class TwigParser
      * @param $block_index
      * @return string
      */
-    public static function hashInlineFileName($template_file, $block_index)
+    public static function hashInlineFileName($template_file, $block_index): string
     {
         // Work around path inconsistencies on Windows/XAMPP.
         if (DIRECTORY_SEPARATOR === '\\') {
@@ -51,7 +51,7 @@ class TwigParser
      * @param  string $template_file
      * @return array
      */
-    public function findSplitPoints($template_file)
+    public function findSplitPoints($template_file): array
     {
         $inline_blocks = 0;
         $source        = new Source(file_get_contents($template_file), $template_file);
@@ -111,7 +111,7 @@ class TwigParser
      * @param  Token  $token
      * @return string
      */
-    private function resolveAssetPath($asset, $template_file, $token)
+    private function resolveAssetPath($asset, $template_file, $token): string
     {
         if (false === ($asset_path = $this->tracker->resolveResourcePath($asset))) {
             throw new \RuntimeException(sprintf(
@@ -140,7 +140,7 @@ class TwigParser
         return $token->getValue();
     }
 
-    private function expect($filename, Token $token, $type, $value = null)
+    private function expect($filename, Token $token, $type, $value = null): void
     {
         if ($token->getType() !== $type) {
             throw new \RuntimeException(sprintf(

--- a/src/Component/Configuration/CodeBlock.php
+++ b/src/Component/Configuration/CodeBlock.php
@@ -77,7 +77,7 @@ class CodeBlock
      * @param  mixed $code
      * @return CodeBlock
      */
-    public function set($chunk, $code)
+    public function set($chunk, $code): CodeBlock
     {
         if (false === \in_array($chunk, $this->types, false)) {
             throw new \InvalidArgumentException(sprintf(
@@ -117,7 +117,7 @@ class CodeBlock
      * @param  string $chunk
      * @return bool
      */
-    public function has($chunk)
+    public function has($chunk): bool
     {
         return isset($this->chunks[$chunk]);
     }

--- a/src/Component/Configuration/Config/OutputConfig.php
+++ b/src/Component/Configuration/Config/OutputConfig.php
@@ -26,7 +26,7 @@ final class OutputConfig implements ConfigInterface, ConfigExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $node_builder
             ->arrayNode('output')

--- a/src/Component/Configuration/Config/ResolveConfig.php
+++ b/src/Component/Configuration/Config/ResolveConfig.php
@@ -33,7 +33,7 @@ final class ResolveConfig implements ConfigInterface, ConfigExtensionInterface
      * @param  string $path
      * @return ResolveConfig
      */
-    public function addAlias($path, $alias = null)
+    public function addAlias($path, $alias = null): ResolveConfig
     {
         $this->config['resolve']['root'][] = $path;
         if ($alias !== null) {
@@ -46,7 +46,7 @@ final class ResolveConfig implements ConfigInterface, ConfigExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $node_builder
             ->arrayNode('resolve')

--- a/src/Component/Configuration/Config/ResolveLoaderConfig.php
+++ b/src/Component/Configuration/Config/ResolveLoaderConfig.php
@@ -31,7 +31,7 @@ final class ResolveLoaderConfig implements ConfigInterface, ConfigExtensionInter
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $node_builder
             ->arrayNode('resolve_loader')

--- a/src/Component/Configuration/ConfigExtensionInterface.php
+++ b/src/Component/Configuration/ConfigExtensionInterface.php
@@ -18,7 +18,6 @@ interface ConfigExtensionInterface extends CodeBlockProviderInterface
      * configuration.
      *
      * @param  NodeBuilder $node_builder
-     * @return string
      */
-    public static function applyConfiguration(NodeBuilder $node_builder);
+    public static function applyConfiguration(NodeBuilder $node_builder): void;
 }

--- a/src/Component/Configuration/ConfigGenerator.php
+++ b/src/Component/Configuration/ConfigGenerator.php
@@ -17,7 +17,7 @@ class ConfigGenerator
      * @param  CodeBlockProviderInterface $entity
      * @return ConfigGenerator
      */
-    public function addExtension(CodeBlockProviderInterface $entity)
+    public function addExtension(CodeBlockProviderInterface $entity): ConfigGenerator
     {
         foreach ($entity->getCodeBlocks() as $block) {
             $this->addBlock($block);
@@ -30,7 +30,7 @@ class ConfigGenerator
      * @param  CodeBlock $block
      * @return ConfigGenerator
      */
-    public function addBlock(CodeBlock $block)
+    public function addBlock(CodeBlock $block): ConfigGenerator
     {
         $this->blocks[] = $block;
 
@@ -96,10 +96,11 @@ class ConfigGenerator
     }
 
     /**
-     * @param  string $type
-     * @param  string|bool $delimiter
-     * @param  string|bool $internal_delimiter
-     * @return string
+     * @param string $type
+     * @param string|bool $delimiter
+     * @param string|bool $internal_delimiter
+     *
+     * @return string|array
      */
     private function getChunks($type, $delimiter = PHP_EOL, $internal_delimiter = PHP_EOL)
     {

--- a/src/Component/Configuration/Loader/BabelLoader.php
+++ b/src/Component/Configuration/Loader/BabelLoader.php
@@ -25,7 +25,7 @@ final class BabelLoader implements LoaderInterface, ConfigExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $node_builder
             ->arrayNode('babel')

--- a/src/Component/Configuration/Loader/CoffeeScriptLoader.php
+++ b/src/Component/Configuration/Loader/CoffeeScriptLoader.php
@@ -25,7 +25,7 @@ final class CoffeeScriptLoader implements LoaderInterface, ConfigExtensionInterf
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $node_builder
             ->arrayNode('coffee')

--- a/src/Component/Configuration/Loader/CssLoader.php
+++ b/src/Component/Configuration/Loader/CssLoader.php
@@ -25,7 +25,7 @@ final class CssLoader implements LoaderInterface, ConfigExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $node_builder
             ->arrayNode('css')

--- a/src/Component/Configuration/Loader/LessLoader.php
+++ b/src/Component/Configuration/Loader/LessLoader.php
@@ -25,7 +25,7 @@ final class LessLoader implements LoaderInterface, ConfigExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $node_builder
             ->arrayNode('less')

--- a/src/Component/Configuration/Loader/SassLoader.php
+++ b/src/Component/Configuration/Loader/SassLoader.php
@@ -25,7 +25,7 @@ final class SassLoader implements LoaderInterface, ConfigExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $node_builder
             ->arrayNode('sass')

--- a/src/Component/Configuration/Loader/TypeScriptLoader.php
+++ b/src/Component/Configuration/Loader/TypeScriptLoader.php
@@ -25,7 +25,7 @@ final class TypeScriptLoader implements LoaderInterface, ConfigExtensionInterfac
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $node_builder
             ->arrayNode('typescript')

--- a/src/Component/Configuration/Loader/UrlLoader.php
+++ b/src/Component/Configuration/Loader/UrlLoader.php
@@ -25,7 +25,7 @@ final class UrlLoader implements LoaderInterface, ConfigExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $node_builder
             ->arrayNode('url')

--- a/src/Component/Configuration/Plugin/DefinePlugin.php
+++ b/src/Component/Configuration/Plugin/DefinePlugin.php
@@ -38,7 +38,7 @@ final class DefinePlugin implements PluginInterface, ConfigExtensionInterface
      * @param  mixed  $value
      * @return DefinePlugin
      */
-    public function add($key, $value)
+    public function add($key, $value): DefinePlugin
     {
         $this->constants[$key] = $value;
 
@@ -48,7 +48,7 @@ final class DefinePlugin implements PluginInterface, ConfigExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $node_builder
             ->arrayNode('constants')

--- a/src/Component/Configuration/Plugin/ProvidePlugin.php
+++ b/src/Component/Configuration/Plugin/ProvidePlugin.php
@@ -22,14 +22,8 @@ final class ProvidePlugin implements PluginInterface, ConfigExtensionInterface
      */
     private $provides;
 
-    /**
-     * @var array
-     */
-    private $config;
-
     public function __construct(array $config = [])
     {
-        $this->config   = $config;
         $this->provides = $config['plugins']['provides'];
     }
 
@@ -38,7 +32,7 @@ final class ProvidePlugin implements PluginInterface, ConfigExtensionInterface
      * @param  mixed  $value
      * @return ProvidePlugin
      */
-    public function add($key, $value)
+    public function add($key, $value): ProvidePlugin
     {
         $this->provides[$key] = $value;
 
@@ -48,7 +42,7 @@ final class ProvidePlugin implements PluginInterface, ConfigExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $node_builder
             ->arrayNode('provides')

--- a/src/Component/Configuration/Plugin/UglifyJsPlugin.php
+++ b/src/Component/Configuration/Plugin/UglifyJsPlugin.php
@@ -50,7 +50,7 @@ final class UglifyJsPlugin implements PluginInterface, ConfigExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public static function applyConfiguration(NodeBuilder $node_builder)
+    public static function applyConfiguration(NodeBuilder $node_builder): void
     {
         $uglify = $node_builder
             ->arrayNode('uglifyjs')

--- a/src/Component/Profiler/Profiler.php
+++ b/src/Component/Profiler/Profiler.php
@@ -17,7 +17,7 @@ class Profiler
      * @param string $key
      * @param mixed  $value
      */
-    public function set($key, $value)
+    public function set($key, $value): void
     {
         $this->logs[$key] = $value;
     }

--- a/src/Component/Profiler/WebpackDataCollector.php
+++ b/src/Component/Profiler/WebpackDataCollector.php
@@ -50,7 +50,7 @@ final class WebpackDataCollector implements DataCollectorInterface
      * @param  mixed  $default
      * @return string
      */
-    public function get($id, $default = false)
+    public function get($id, $default = false): string
     {
         return $this->profiler->get($id, $default);
     }

--- a/test/Bundle/CacheWarmer/WebpackCompileCacheWarmerTest.php
+++ b/test/Bundle/CacheWarmer/WebpackCompileCacheWarmerTest.php
@@ -17,7 +17,7 @@ class WebpackCompileCacheWarmerTest extends TestCase
     /**
      * Simple test to see the guard is executed from the cache warmer.
      */
-    public function testWebpackCompileCacheWarmer()
+    public function testWebpackCompileCacheWarmer(): void
     {
         $guard = $this->prophesize(CacheGuard::class);
         $guard->rebuild()->shouldBeCalled();

--- a/test/Bundle/Command/CompileCommandTest.php
+++ b/test/Bundle/Command/CompileCommandTest.php
@@ -19,7 +19,7 @@ class CompileCommandTest extends TestCase
     /**
      * Simple test to see the validate function is executed from the CacheGard class.
      */
-    public function testCompileCommand()
+    public function testCompileCommand(): void
     {
         $guard = $this->prophesize(CacheGuard::class);
         $guard->rebuild()->shouldBeCalled();

--- a/test/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/test/Bundle/DependencyInjection/ConfigurationTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfigurationTest extends TestCase
 {
-    public function testGetConfigTreeBuilder()
+    public function testGetConfigTreeBuilder(): void
     {
         $config = new Configuration([], [DefinePlugin::class, CssLoader::class]);
         $tree   = $config->getConfigTreeBuilder();

--- a/test/Bundle/DependencyInjection/WebpackExtensionTest.php
+++ b/test/Bundle/DependencyInjection/WebpackExtensionTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class WebpackExtensionTest extends TestCase
 {
-    public function testAlias()
+    public function testAlias(): void
     {
         self::assertEquals(Configuration::CONFIG_ROOT, (new WebpackExtension())->getAlias());
     }
@@ -22,7 +22,7 @@ class WebpackExtensionTest extends TestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testLoadNoConfig()
+    public function testLoadNoConfig(): void
     {
         $container = new ContainerBuilder();
         $extension = new WebpackExtension();

--- a/test/Bundle/Twig/Token/WebpackTokenParserTest.php
+++ b/test/Bundle/Twig/Token/WebpackTokenParserTest.php
@@ -15,7 +15,7 @@ use Twig\Loader\LoaderInterface;
  */
 class WebpackTokenParserTest extends TestCase
 {
-    public function testParser()
+    public function testParser(): void
     {
         $loader    = $this->prophesize(LoaderInterface::class)->reveal();
         $extension = new TwigExtension(

--- a/test/Bundle/Twig/TwigExtensionTest.php
+++ b/test/Bundle/Twig/TwigExtensionTest.php
@@ -14,7 +14,7 @@ use Twig\Loader\LoaderInterface;
  */
 class TwigExtensionTest extends TestCase
 {
-    public function testExtension()
+    public function testExtension(): void
     {
         $loader    = $this->prophesize(LoaderInterface::class)->reveal();
         $extension = new TwigExtension($loader, __DIR__, '/', '/bundles', '/shared.js', '/shared.css');
@@ -28,7 +28,7 @@ class TwigExtensionTest extends TestCase
     /**
      * @dataProvider assetProvider
      */
-    public function testAssets($expected, $asset, $web_dir, $dump_path, $public_path)
+    public function testAssets($expected, $asset, $web_dir, $dump_path, $public_path): void
     {
         $loader    = $this->prophesize(LoaderInterface::class)->reveal();
         $extension = new TwigExtension($loader, $web_dir, $public_path, $dump_path, '', '');

--- a/test/Bundle/WebpackBundleTest.php
+++ b/test/Bundle/WebpackBundleTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class WebpackBundleTest extends TestCase
 {
-    public function testBuild()
+    public function testBuild(): void
     {
         $bundle    = new WebpackBundle();
         $container = new ContainerBuilder();

--- a/test/Component/Asset/CacheGuardTest.php
+++ b/test/Component/Asset/CacheGuardTest.php
@@ -17,7 +17,7 @@ class CacheGuardTest extends TestCase
     /**
      * Simple test for the case the cache is outdated.
      */
-    public function testCacheOutdated()
+    public function testCacheOutdated(): void
     {
         $compiler = $this->prophesize(Compiler::class);
         $compiler->compile()->willReturn('some debug output');
@@ -42,7 +42,7 @@ class CacheGuardTest extends TestCase
     /**
      * Simple test for the case the cache is not outdated.
      */
-    public function testCacheUpToDate()
+    public function testCacheUpToDate(): void
     {
         $compiler = $this->prophesize(Compiler::class);
         $compiler->compile()->willReturn('some debug output')->shouldNotBeCalled();

--- a/test/Component/Asset/CompilerTest.php
+++ b/test/Component/Asset/CompilerTest.php
@@ -23,7 +23,7 @@ class CompilerTest extends TestCase
     private $process;
     private $cache_path;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->profiler    = $this->getMockBuilder(Profiler::class)->disableOriginalConstructor()->getMock();
         $this->tracker     = $this->getMockBuilder(Tracker::class)->disableOriginalConstructor()->getMock();
@@ -33,7 +33,7 @@ class CompilerTest extends TestCase
         $this->cache_path  = realpath(__DIR__ . '/../../Fixture/cache');
     }
 
-    public function testCompile()
+    public function testCompile(): void
     {
         $this->tracker->expects($this->once())->method('getTemplates')->willReturn(['foobar']);
         $this->tracker->expects($this->once())->method('getAliases')->willReturn(['@AppBundle' => 'foobar']);

--- a/test/Component/Asset/DumperTest.php
+++ b/test/Component/Asset/DumperTest.php
@@ -25,7 +25,7 @@ class DumperTest extends TestCase
      */
     private $fixture_path;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->fixture_path = realpath(__DIR__ . '/../../Fixture');
         $this->dumper       = new Dumper(
@@ -48,7 +48,7 @@ class DumperTest extends TestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testDumpDefaults()
+    public function testDumpDefaults(): void
     {
         $this->dumper->dump();
     }

--- a/test/Component/Asset/TemplateFinderTest.php
+++ b/test/Component/Asset/TemplateFinderTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright 2019-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\Webpack\Asset;
+
+use Hostnet\Fixture\WebpackBundle\Bundle\BarBundle\BarBundle;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * @covers \Hostnet\Component\Webpack\Asset\TemplateFinder
+ */
+class TemplateFinderTest extends TestCase
+{
+    public function testFindAllTemplates(): void
+    {
+        $kernel = $this->prophesize(Kernel::class);
+        $kernel->getBundle()->shouldNotBeCalled();
+        $kernel->getBundles()->willReturn(['BaseBundle' => new BarBundle()]);
+
+        $finder = new TemplateFinder($kernel->reveal(), __DIR__ . '/../Fixtures/Resources');
+
+        $templates = array_map(function ($template) {
+            return $template->getLogicalName();
+        }, $finder->findAllTemplates());
+
+        self::assertCount(3, $templates);
+        self::assertContains('BarBundle::base.format.engine', $templates);
+        self::assertContains('BarBundle::this.is.a.template.format.engine', $templates);
+        self::assertContains('BarBundle:controller:base.format.engine', $templates);
+    }
+}

--- a/test/Component/Asset/TemplateReferenceTest.php
+++ b/test/Component/Asset/TemplateReferenceTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright 2019-present Hostnet B.V.
+ */
+declare(strict_types=1);
+
+namespace Hostnet\Component\Webpack\Asset;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Hostnet\Component\Webpack\Asset\TemplateReference
+ */
+class TemplateReferenceTest extends TestCase
+{
+    public function testGeneric(): void
+    {
+        $reference = new TemplateReference('AcmeBlogBundle', 'Admin\Post', 'index', 'html', 'twig');
+        self::assertSame('@AcmeBlogBundle/Resources/views/Admin/Post/index.html.twig', $reference->getPath());
+        self::assertSame('AcmeBlogBundle:Admin\Post:index.html.twig', $reference->getLogicalName());
+
+        $reference = new TemplateReference(null, 'Admin\Post', 'index', 'html', 'twig');
+        self::assertSame('views/Admin/Post/index.html.twig', $reference->getPath());
+        self::assertSame(':Admin\Post:index.html.twig', $reference->getLogicalName());
+    }
+}

--- a/test/Component/Asset/TrackedFilesTest.php
+++ b/test/Component/Asset/TrackedFilesTest.php
@@ -36,7 +36,7 @@ class TrackedFilesTest extends TestCase
      *
      * {@inheritDoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->directory_a = tempnam(sys_get_temp_dir(), 'tracked_files_unittest_a');
         unlink($this->directory_a);
@@ -52,7 +52,7 @@ class TrackedFilesTest extends TestCase
      *
      * {@inheritDoc}
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $fs = new Filesystem();
         $fs->remove($this->directory_a);
@@ -62,7 +62,7 @@ class TrackedFilesTest extends TestCase
     /**
      * Test the behavior for empty / no directories
      */
-    public function testTrackedFilesEmpty()
+    public function testTrackedFilesEmpty(): void
     {
         $t1 = new TrackedFiles([$this->directory_a]);
         $t2 = new TrackedFiles([$this->directory_b]);
@@ -77,7 +77,7 @@ class TrackedFilesTest extends TestCase
     /**
      * What happens when a file is added after 'compilation'
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $time = time();
 
@@ -98,7 +98,7 @@ class TrackedFilesTest extends TestCase
     /**
      * What happens when a file is removed after 'compilation'
      */
-    public function testDel()
+    public function testDel(): void
     {
         $time = time();
 
@@ -121,7 +121,7 @@ class TrackedFilesTest extends TestCase
     /**
      * What happens when a file is modified before 'compilation'
      */
-    public function testModifyBefore()
+    public function testModifyBefore(): void
     {
         $time = time();
 
@@ -142,7 +142,7 @@ class TrackedFilesTest extends TestCase
     /**
      * What happens when a file is modified after 'compilation'
      */
-    public function testModifyAfter()
+    public function testModifyAfter(): void
     {
         $time = time();
 

--- a/test/Component/Asset/TwigParserTest.php
+++ b/test/Component/Asset/TwigParserTest.php
@@ -31,14 +31,14 @@ class TwigParserTest extends TestCase
     private $cache_dir;
 
     /** {@inheritdoc} */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->tracker   = $this->getMockBuilder(Tracker::class)->disableOriginalConstructor()->getMock();
         $this->twig      = new Environment(new ArrayLoader([]));
         $this->cache_dir = sys_get_temp_dir();
     }
 
-    public function testParseValid()
+    public function testParseValid(): void
     {
         // Call count expectations:
         //  1: webpack_asset.js
@@ -69,27 +69,25 @@ class TwigParserTest extends TestCase
         self::assertContains('foobar', $points);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage template_parse_error.html.twig at line 3. Expected punctuation "(", got name.
-     */
-    public function testParseError()
+    public function testParseError(): void
     {
         $this->tracker->expects($this->never())->method('resolveResourcePath');
-
         $parser = new TwigParser($this->tracker, $this->twig, $this->cache_dir);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('template_parse_error.html.twig at line 3. Expected punctuation "(", got name.');
+
         $parser->findSplitPoints(__DIR__ . '/Fixtures/template_parse_error.html.twig');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage at line 3 could not be resolved.
-     */
-    public function testResolveError()
+    public function testResolveError(): void
     {
         $this->tracker->expects($this->once())->method('resolveResourcePath')->willReturn(false);
-
         $parser = new TwigParser($this->tracker, $this->twig, $this->cache_dir);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('at line 3 could not be resolved.');
+
         $parser->findSplitPoints(__DIR__ . '/Fixtures/template.html.twig');
     }
 }

--- a/test/Component/Configuration/CodeBlockTest.php
+++ b/test/Component/Configuration/CodeBlockTest.php
@@ -15,37 +15,35 @@ use PHPUnit\Framework\TestCase;
  */
 class CodeBlockTest extends TestCase
 {
-    public function testCodeBlock()
+    public function testCodeBlock(): void
     {
         $block = (new CodeBlock())->set(CodeBlock::HEADER, 'foo');
         self::assertTrue($block->has(CodeBlock::HEADER));
         self::assertEquals('foo', $block->get(CodeBlock::HEADER));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInvalidChunk()
+    public function testInvalidChunk(): void
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         (new CodeBlock())->set('foobar', true);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testGetInvalid()
+    public function testGetInvalid(): void
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         (new CodeBlock())->get(CodeBlock::HEADER);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The chunk "header" is already in use.
-     */
-    public function testDuplicateChunk()
+    public function testDuplicateChunk(): void
     {
         $block = new CodeBlock();
         $block->set(CodeBlock::HEADER, 'foo');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The chunk "header" is already in use.');
+
         $block->set(CodeBlock::HEADER, 'bar');
     }
 }

--- a/test/Component/Configuration/Config/OutputConfigTest.php
+++ b/test/Component/Configuration/Config/OutputConfigTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class OutputConfigTest extends AbstractTestCase
 {
-    public function testConfigTreeBuilder()
+    public function testConfigTreeBuilder(): void
     {
         $tree = $this->createTreeBuilder('webpack');
         $node = $this->retrieveRootNode($tree, 'webpack')->children();
@@ -43,7 +43,7 @@ class OutputConfigTest extends AbstractTestCase
         self::assertArrayHasKey('path_info', $config['output']);
     }
 
-    public function testGetCodeBlock()
+    public function testGetCodeBlock(): void
     {
         $config = new OutputConfig([
             'output' => [

--- a/test/Component/Configuration/Config/ResolveConfigTest.php
+++ b/test/Component/Configuration/Config/ResolveConfigTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class ResolveConfigTest extends AbstractTestCase
 {
-    public function testConfigTreeBuilder()
+    public function testConfigTreeBuilder(): void
     {
         $tree = $this->createTreeBuilder('webpack');
         $node = $this->retrieveRootNode($tree, 'webpack')->children();
@@ -34,7 +34,7 @@ class ResolveConfigTest extends AbstractTestCase
         self::assertArrayHasKey('extensions', $config['resolve']);
     }
 
-    public function testGetCodeBlock()
+    public function testGetCodeBlock(): void
     {
         $config = new ResolveConfig([
             'node' => [

--- a/test/Component/Configuration/Config/ResolveLoaderConfigTest.php
+++ b/test/Component/Configuration/Config/ResolveLoaderConfigTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class ResolveLoaderConfigTest extends AbstractTestCase
 {
-    public function testConfigTreeBuilder()
+    public function testConfigTreeBuilder(): void
     {
         $tree = $this->createTreeBuilder('webpack');
         $node = $this->retrieveRootNode($tree, 'webpack')->children();
@@ -28,7 +28,7 @@ class ResolveLoaderConfigTest extends AbstractTestCase
         self::assertArrayHasKey('resolve_loader', $config);
     }
 
-    public function testGetCodeBlock()
+    public function testGetCodeBlock(): void
     {
         $config = new ResolveLoaderConfig([
             'node' => [

--- a/test/Component/Configuration/ConfigGeneratorTest.php
+++ b/test/Component/Configuration/ConfigGeneratorTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfigGeneratorTest extends TestCase
 {
-    public function testBuild()
+    public function testBuild(): void
     {
         $config = new ConfigGenerator();
         $config

--- a/test/Component/Configuration/Loader/BabelLoaderTest.php
+++ b/test/Component/Configuration/Loader/BabelLoaderTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class BabelLoaderTest extends AbstractTestCase
 {
-    public function testConfigTreeBuilder()
+    public function testConfigTreeBuilder(): void
     {
         $tree = $this->createTreeBuilder('webpack');
         $node = $this->retrieveRootNode($tree, 'webpack')->children();
@@ -30,7 +30,7 @@ class BabelLoaderTest extends AbstractTestCase
         self::assertArrayHasKey('enabled', $config['babel']);
     }
 
-    public function testGetCodeBlockDefault()
+    public function testGetCodeBlockDefault(): void
     {
         $config = new BabelLoader();
         $block  = $config->getCodeBlocks()[0];
@@ -38,7 +38,7 @@ class BabelLoaderTest extends AbstractTestCase
         self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
-    public function testGetCodeBlockDisabled()
+    public function testGetCodeBlockDisabled(): void
     {
         $config = new BabelLoader(['loaders' => ['babel' => ['enabled' => false]]]);
         $block  = $config->getCodeBlocks()[0];
@@ -46,7 +46,7 @@ class BabelLoaderTest extends AbstractTestCase
         self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
-    public function testGetCodeBlock()
+    public function testGetCodeBlock(): void
     {
         $config = new BabelLoader(['loaders' => ['babel' => ['enabled' => true]]]);
         $block  = $config->getCodeBlocks()[0];

--- a/test/Component/Configuration/Loader/CoffeeScriptLoaderTest.php
+++ b/test/Component/Configuration/Loader/CoffeeScriptLoaderTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class CoffeeScriptLoaderTest extends AbstractTestCase
 {
-    public function testConfigTreeBuilder()
+    public function testConfigTreeBuilder(): void
     {
         $tree = $this->createTreeBuilder('webpack');
         $node = $this->retrieveRootNode($tree, 'webpack')->children();
@@ -30,7 +30,7 @@ class CoffeeScriptLoaderTest extends AbstractTestCase
         self::assertArrayHasKey('enabled', $config['coffee']);
     }
 
-    public function testGetCodeBlockDisabled()
+    public function testGetCodeBlockDisabled(): void
     {
         $config = new CoffeeScriptLoader(['loaders' => ['coffee' => ['enabled' => false, 'loader' => 'coffee']]]);
         $block  = $config->getCodeBlocks()[0];
@@ -38,7 +38,7 @@ class CoffeeScriptLoaderTest extends AbstractTestCase
         self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
-    public function testGetCodeBlock()
+    public function testGetCodeBlock(): void
     {
         $config = new CoffeeScriptLoader(['loaders' => ['coffee' => ['enabled' => true, 'loader' => 'coffee']]]);
         $block  = $config->getCodeBlocks()[0];

--- a/test/Component/Configuration/Loader/CssLoaderTest.php
+++ b/test/Component/Configuration/Loader/CssLoaderTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class CssLoaderTest extends AbstractTestCase
 {
-    public function testConfigTreeBuilder()
+    public function testConfigTreeBuilder(): void
     {
         $tree = $this->createTreeBuilder('webpack');
         $node = $this->retrieveRootNode($tree, 'webpack')->children();
@@ -32,14 +32,14 @@ class CssLoaderTest extends AbstractTestCase
         self::assertArrayHasKey('filename', $config['css']);
     }
 
-    public function testGetCodeBlockDisabled()
+    public function testGetCodeBlockDisabled(): void
     {
         $config = new CssLoader(['loaders' => ['css' => ['enabled' => false]]]);
 
         self::assertFalse($config->getCodeBlocks()[0]->has(CodeBlock::LOADER));
     }
 
-    public function testGetCodeBlockEnabledDefaults()
+    public function testGetCodeBlockEnabledDefaults(): void
     {
         $configs = (new CssLoader(['loaders' => ['css' => ['enabled' => true]]]))->getCodeBlocks();
 
@@ -48,7 +48,7 @@ class CssLoaderTest extends AbstractTestCase
         self::assertFalse($configs[0]->has(CodeBlock::PLUGIN));
     }
 
-    public function testGetCodeBlockEnabledCommonsChunk()
+    public function testGetCodeBlockEnabledCommonsChunk(): void
     {
         $configs = (new CssLoader([
             'output'  => ['common_id' => 'foobar'],

--- a/test/Component/Configuration/Loader/LessLoaderTest.php
+++ b/test/Component/Configuration/Loader/LessLoaderTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class LessLoaderTest extends AbstractTestCase
 {
-    public function testConfigTreeBuilder()
+    public function testConfigTreeBuilder(): void
     {
         $tree = $this->createTreeBuilder('webpack');
         $node = $this->retrieveRootNode($tree, 'webpack')->children();
@@ -30,7 +30,7 @@ class LessLoaderTest extends AbstractTestCase
         self::assertArrayHasKey('enabled', $config['less']);
     }
 
-    public function testGetCodeBlockDisabled()
+    public function testGetCodeBlockDisabled(): void
     {
         $config = new LessLoader(['loaders' => ['less' => ['enabled' => false]]]);
         $block  = $config->getCodeBlocks()[0];
@@ -38,7 +38,7 @@ class LessLoaderTest extends AbstractTestCase
         self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
-    public function testGetCodeBlock()
+    public function testGetCodeBlock(): void
     {
         $config = new LessLoader(['loaders' => ['less' => ['enabled' => true]]]);
         $block  = $config->getCodeBlocks()[0];

--- a/test/Component/Configuration/Loader/SassLoaderTest.php
+++ b/test/Component/Configuration/Loader/SassLoaderTest.php
@@ -14,7 +14,7 @@ use Hostnet\Tests\AbstractTestCase;
  */
 class SassLoaderTest extends AbstractTestCase
 {
-    public function testConfigTreeBuilder()
+    public function testConfigTreeBuilder(): void
     {
         $tree = $this->createTreeBuilder('webpack');
         $node = $this->retrieveRootNode($tree, 'webpack')->children();
@@ -28,7 +28,7 @@ class SassLoaderTest extends AbstractTestCase
         self::assertArrayHasKey('enabled', $config['sass']);
     }
 
-    public function testGetCodeBlockDisabled()
+    public function testGetCodeBlockDisabled(): void
     {
         $config = new SassLoader(['loaders' => ['sass' => ['enabled' => false]]]);
         $block  = $config->getCodeBlocks()[0];
@@ -36,7 +36,7 @@ class SassLoaderTest extends AbstractTestCase
         self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
-    public function testGetCodeBlock()
+    public function testGetCodeBlock(): void
     {
         $config = new SassLoader(['loaders' => ['sass' => ['enabled' => true]]]);
         $block  = $config->getCodeBlocks()[0];
@@ -44,7 +44,7 @@ class SassLoaderTest extends AbstractTestCase
         self::assertTrue($block->has(CodeBlock::LOADER));
     }
 
-    public function testGetCodeBlockWithIncludePaths()
+    public function testGetCodeBlockWithIncludePaths(): void
     {
         $config = new SassLoader(
             [

--- a/test/Component/Configuration/Loader/TypeScriptLoaderTest.php
+++ b/test/Component/Configuration/Loader/TypeScriptLoaderTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class TypeScriptLoaderTest extends AbstractTestCase
 {
-    public function testConfigTreeBuilder()
+    public function testConfigTreeBuilder(): void
     {
         $tree = $this->createTreeBuilder('webpack');
         $node = $this->retrieveRootNode($tree, 'webpack')->children();
@@ -30,7 +30,7 @@ class TypeScriptLoaderTest extends AbstractTestCase
         self::assertArrayHasKey('enabled', $config['typescript']);
     }
 
-    public function testGetCodeBlockDisabled()
+    public function testGetCodeBlockDisabled(): void
     {
         $config = new TypeScriptLoader(['loaders' => ['typescript' => ['enabled' => false, 'loader' => 'ts']]]);
         $block  = $config->getCodeBlocks()[0];
@@ -38,7 +38,7 @@ class TypeScriptLoaderTest extends AbstractTestCase
         self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
-    public function testGetCodeBlock()
+    public function testGetCodeBlock(): void
     {
         $config = new TypeScriptLoader(['loaders' => ['typescript' => ['enabled' => true, 'loader' => 'ts']]]);
         $block  = $config->getCodeBlocks()[0];

--- a/test/Component/Configuration/Loader/UrlLoaderTest.php
+++ b/test/Component/Configuration/Loader/UrlLoaderTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class UrlLoaderTest extends AbstractTestCase
 {
-    public function testConfigTreeBuilder()
+    public function testConfigTreeBuilder(): void
     {
         $tree = $this->createTreeBuilder('webpack');
         $node = $this->retrieveRootNode($tree, 'webpack')->children();
@@ -31,7 +31,7 @@ class UrlLoaderTest extends AbstractTestCase
         self::assertArrayHasKey('enabled', $config['url']);
     }
 
-    public function testGetCodeBlockDisabled()
+    public function testGetCodeBlockDisabled(): void
     {
         $config = new UrlLoader(['loaders' => ['url' => ['enabled' => false]]]);
         $block  = $config->getCodeBlocks()[0];
@@ -39,7 +39,7 @@ class UrlLoaderTest extends AbstractTestCase
         self::assertFalse($block->has(CodeBlock::LOADER));
     }
 
-    public function testGetFontExtensionCodeBlock()
+    public function testGetFontExtensionCodeBlock(): void
     {
         $config = new UrlLoader([
             'loaders' => ['url' => ['enabled' => true, 'font_extensions' => 'svg,woff', 'limit' => 100]],
@@ -50,7 +50,7 @@ class UrlLoaderTest extends AbstractTestCase
         self::assertTrue($block->has(CodeBlock::LOADER));
     }
 
-    public function testGetImageExtensionCodeBlock()
+    public function testGetImageExtensionCodeBlock(): void
     {
         $config = new UrlLoader([
             'loaders' => ['url' => ['enabled' => true, 'image_extensions' => 'png', 'limit' => 100]],

--- a/test/Component/Configuration/Plugin/DefinePluginTest.php
+++ b/test/Component/Configuration/Plugin/DefinePluginTest.php
@@ -19,7 +19,7 @@ class DefinePluginTest extends AbstractTestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testConfigTreeBuilder()
+    public function testConfigTreeBuilder(): void
     {
         $tree = $this->createTreeBuilder('webpack');
         $node = $this->retrieveRootNode($tree, 'webpack')->children();
@@ -30,7 +30,7 @@ class DefinePluginTest extends AbstractTestCase
         $config = $tree->buildTree()->finalize([]);
     }
 
-    public function testGetCodeBlock()
+    public function testGetCodeBlock(): void
     {
         $config = new DefinePlugin([
             'plugins' => [

--- a/test/Component/Configuration/Plugin/ProvidePluginTest.php
+++ b/test/Component/Configuration/Plugin/ProvidePluginTest.php
@@ -19,7 +19,7 @@ class ProvidePluginTest extends AbstractTestCase
     /**
      * @doesNotPerformAssertions
      */
-    public function testConfigTreeBuilder()
+    public function testConfigTreeBuilder(): void
     {
         $tree = $this->createTreeBuilder('webpack');
         $node = $this->retrieveRootNode($tree, 'webpack')->children();
@@ -30,7 +30,7 @@ class ProvidePluginTest extends AbstractTestCase
         $config = $tree->buildTree()->finalize([]);
     }
 
-    public function testGetCodeBlock()
+    public function testGetCodeBlock(): void
     {
         $config = new ProvidePlugin([
             'plugins' => [

--- a/test/Component/Profiler/WebpackDataCollectorTest.php
+++ b/test/Component/Profiler/WebpackDataCollectorTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class WebpackDataCollectorTest extends TestCase
 {
-    public function testProfiler()
+    public function testProfiler(): void
     {
         $profiler  = new Profiler();
         $collector = new WebpackDataCollector($profiler);

--- a/test/Fixture/config/config.yml
+++ b/test/Fixture/config/config.yml
@@ -3,8 +3,6 @@ parameters:
 
 framework:
     secret: test
-    templating:
-        engine: [twig]
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
 

--- a/test/Functional/AssetTest.php
+++ b/test/Functional/AssetTest.php
@@ -19,7 +19,7 @@ class AssetTest extends KernelTestCase
         return TestKernel::class;
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         static::bootKernel();
         $this->compiled = static::$kernel->getContainer()->getParameter('kernel.root_dir') . '/cache/compiled/';
@@ -29,7 +29,7 @@ class AssetTest extends KernelTestCase
         }
     }
 
-    public function testPublicAsset()
+    public function testPublicAsset(): void
     {
         static::bootKernel();
 
@@ -39,7 +39,7 @@ class AssetTest extends KernelTestCase
         self::assertEquals('/bundles/henk.png', $twig_ext->webpackPublic('henk.png'));
     }
 
-    public function testCompiledAsset()
+    public function testCompiledAsset(): void
     {
         /** @var TwigExtension $twig_ext */
         $container = static::$kernel->getContainer();
@@ -54,11 +54,11 @@ class AssetTest extends KernelTestCase
         touch($this->compiled . 'app.henk.css');
 
         $resources = $twig_ext->webpackAsset('@App/henk.js');
-        self::assertContains('app.henk.js?', (string) $resources['js']);
-        self::assertContains('app.henk.css?', (string) $resources['css']);
+        self::assertStringContainsString('app.henk.js?', (string) $resources['js']);
+        self::assertStringContainsString('app.henk.css?', (string) $resources['css']);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         shell_exec("rm -rf {$this->compiled}");
 

--- a/test/Functional/CompileTest.php
+++ b/test/Functional/CompileTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 class CompileTest extends KernelTestCase
 {
-    public function testDevCollector()
+    public function testDevCollector(): void
     {
         static::bootKernel(['environment' => 'dev', 'debug' => false]);
         $collector = static::$kernel->getContainer()->get(WebpackDataCollector::class);
@@ -21,7 +21,7 @@ class CompileTest extends KernelTestCase
         self::assertInstanceOf(WebpackDataCollector::class, $collector);
     }
 
-    public function testMissingCollector()
+    public function testMissingCollector(): void
     {
         $this->expectException(ServiceNotFoundException::class);
 
@@ -29,7 +29,7 @@ class CompileTest extends KernelTestCase
         static::$kernel->getContainer()->get(WebpackDataCollector::class);
     }
 
-    public function testTrackedTemplates()
+    public function testTrackedTemplates(): void
     {
         static::bootKernel();
 

--- a/test/Functional/ConfigGeneratorTest.php
+++ b/test/Functional/ConfigGeneratorTest.php
@@ -12,7 +12,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class ConfigGeneratorTest extends KernelTestCase
 {
-    public function testExternalExtensions()
+    public function testExternalExtensions(): void
     {
         static::bootKernel();
 
@@ -25,6 +25,6 @@ class ConfigGeneratorTest extends KernelTestCase
         $contiguration = $config_generator->getConfiguration();
 
         self::assertTrue($mock_loader->code_blocks_called);
-        self::assertContains(MockLoader::BLOCK_CONTENT, $contiguration);
+        self::assertStringContainsString(MockLoader::BLOCK_CONTENT, $contiguration);
     }
 }

--- a/test/Functional/DumperTest.php
+++ b/test/Functional/DumperTest.php
@@ -17,14 +17,14 @@ class DumperTest extends KernelTestCase
      */
     private $dir;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         static::bootKernel();
 
         $this->dir = Path::BASE_DIR . '/test/Fixture/cache/bundles';
     }
 
-    public function testDump()
+    public function testDump(): void
     {
         static::bootKernel();
 
@@ -35,7 +35,7 @@ class DumperTest extends KernelTestCase
         self::assertFileExists($this->dir . '/foo/public.js');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         shell_exec("rm -rf $this->dir");
 

--- a/test/Functional/TwigTest.php
+++ b/test/Functional/TwigTest.php
@@ -15,12 +15,12 @@ use Symfony\Bundle\TwigBundle\TwigEngine;
  */
 class TwigTest extends KernelTestCase
 {
-    public function testTemplates()
+    public function testTemplates(): void
     {
         static::bootKernel();
 
         /** @var TwigEngine $twig_ext */
-        $twig = static::$kernel->getContainer()->get('templating');
+        $twig = static::$kernel->getContainer()->get('twig');
         $html = $twig->render('/common_id.html.twig');
 
         self::assertRegExp('~src="/compiled/shared\.js\?[0-9]+"~', $html);


### PR DESCRIPTION
The [Templating](https://symfony.com/blog/new-in-symfony-4-3-deprecated-the-templating-component-integration) component will be removed in Symfony 5, so I've extracted the few classes that we actually use and resolved all other deprecation issues.

If this PR is merged, #89 can be closed since this fixes all issues we currently have on Travis.