### PR TITLE
removed hhvm from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     - php: nightly
 
 before_install:
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then phpenv config-rm xdebug.ini; fi
+  - phpenv config-rm xdebug.ini
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi
 


### PR DESCRIPTION
see:

- https://symfony.com/blog/symfony-4-end-of-hhvm-support
- https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html