### PR TITLE
fixed incorrect return-type in data-profiler

### DIFF
--- a/src/Component/Profiler/WebpackDataCollector.php
+++ b/src/Component/Profiler/WebpackDataCollector.php
@@ -48,9 +48,9 @@ final class WebpackDataCollector implements DataCollectorInterface
     /**
      * @param  string $id
      * @param  mixed  $default
-     * @return string
+     * @return null|string
      */
-    public function get($id, $default = false): string
+    public function get($id, $default = false): ?string
     {
         return $this->profiler->get($id, $default);
     }

--- a/test/Component/Profiler/WebpackDataCollectorTest.php
+++ b/test/Component/Profiler/WebpackDataCollectorTest.php
@@ -20,13 +20,16 @@ class WebpackDataCollectorTest extends TestCase
     {
         $profiler  = new Profiler();
         $collector = new WebpackDataCollector($profiler);
-        $profiler->set('foobar', 'hoi');
         $collector->collect(
             $this->getMockBuilder(Request::class)->getMock(),
             $this->getMockBuilder(Response::class)->getMock()
         );
 
-        self::assertEquals('hoi', $collector->get('foobar'));
         self::assertEquals('webpack', $collector->getName());
+        self::assertNull($collector->get('foobar'));
+
+        $profiler->set('foobar', 'hoi');
+
+        self::assertEquals('hoi', $collector->get('foobar'));
     }
 }


### PR DESCRIPTION
The profiler is broken in since version 2.0.6 due to an incorrect typehint in the datacollector.