### PR TITLE
added abandoned notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+**Abandoned**
+
+This package is abandoned.
+Use alternative tools like:
+
+- [hostnet/asset-bundle]('https://github.com/hostnet/asset-bundle')
+- [Webpack Encore]('https://symfony.com/doc/4.4/frontend.html')
+
+
 # hostnet/webpack-bundle
 
 - [Introduction](#introduction)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This package is abandoned.
 Use alternative tools like:
 
-- [hostnet/asset-bundle]('https://github.com/hostnet/asset-bundle')
-- [Webpack Encore]('https://symfony.com/doc/4.4/frontend.html')
+- [hostnet/asset-bundle](https://github.com/hostnet/asset-bundle)
+- [Webpack Encore](https://symfony.com/doc/4.4/frontend.html)
 
 
 # hostnet/webpack-bundle

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "type":        "symfony-bundle",
     "description": "Integrates Webpack with Symfony",
     "license":     "MIT",
+    "abandoned":   true,
     "require": {
         "php":                    "^7.1.0",
         "ext-json":               "*",


### PR DESCRIPTION
The webpack-bundle is no longer maintained and used by Hostnet. The [asset-bundle]('https://github.com/hostnet/asset-bundle') is an alternative or Webpack Encore can be used as a webpack replacement.